### PR TITLE
AMEC-2423: Remove XML markup from page titles

### DIFF
--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/common/head.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/common/head.ftl
@@ -1,4 +1,5 @@
 <#include "../macro/pathUp.ftl" />
+<#include "../macro/removeTags.ftl" />
 <#include "title/titleFormat.ftl" />
 
 <head>
@@ -19,7 +20,7 @@
     }
   </style>
 
-  <title><@titleFormat title /></title>
+  <title><@titleFormat removeTags(title) /></title>
 <@cssLink target=pathUp(depth!0 "static/css/base.css") />
 <@cssLink target=pathUp(depth!0 "static/css/interface.css") />
 <@cssLink target=pathUp(depth!0 "static/css/mobile.css") />

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/macro/removeTags.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/macro/removeTags.ftl
@@ -1,0 +1,17 @@
+<#--
+
+  Removes XML tags from a string, but leaves the text between the tags. For example, changes
+    A <italic>Staphylococcus aureus</italic> Small RNA
+  to
+    A Staphylococcus aureus Small RNA
+
+  This solution is quick and dirty; there are almost certainly edge-case bugs. One is if a tag attribute contains a '>'
+  character, e.g.
+    <tag mode="foo -> bar">
+  A real XML library is generally preferable to such hacking, but it's difficult to apply one here because there isn't
+  really an XML document to parse, just snippets of text that happen to contain XML syntax.
+
+  -->
+<#function removeTags string>
+  <#return string?replace('</?[^<>]*>', '', 'r') />
+</#function>


### PR DESCRIPTION
Is everyone okay with doing this in the view layer and not by modifying the text in the controller (or in Rhino for that matter)?

Btw, longer-term issue to think about -- it isn't great that the service API provides these snippets of NLM XML when they can't be used properly without a full XML document. See the comment in removeTags.ftl and on the AMEC-2423 ticket.
