### PR TITLE
On cache errors, log the error and treat it as a cache miss

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/SoaServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/SoaServiceImpl.java
@@ -7,6 +7,8 @@ import org.ambraproject.wombat.config.RuntimeConfiguration;
 import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.BufferedInputStream;
@@ -19,6 +21,7 @@ import java.util.Calendar;
 import java.util.Map;
 
 public class SoaServiceImpl extends JsonService implements SoaService {
+  private static final Logger log = LoggerFactory.getLogger(SoaServiceImpl.class);
 
   @Autowired
   private RuntimeConfiguration runtimeConfiguration;
@@ -77,7 +80,15 @@ public class SoaServiceImpl extends JsonService implements SoaService {
     Preconditions.checkNotNull(address);
     Preconditions.checkNotNull(callback);
 
-    CachedObject<T> cached = cache.get(cacheKey);
+    CachedObject<T> cached;
+    try {
+      cached = cache.get(cacheKey);
+    } catch (Exception e) {
+      // Unexpected, but to degrade gracefully, treat it the same as a cache miss
+      log.error("Error accessing cache", e);
+      cached = null;
+    }
+
     Calendar lastModified;
     if (cached == null) {
       lastModified = Calendar.getInstance();


### PR DESCRIPTION
Per discussion last week.

Should we talk to Ops about their preferences in this area? Before, the symptom of Memcached being down would have been page-display failures. With this, it would be a probable performance slowdown plus stack traces being spammed to the logs.
