### PR TITLE
DPRO-290: Make relative links to assets absolute

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/common/head.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/common/head.ftl
@@ -14,9 +14,9 @@
     <![endif]-->
 
 
-  <script type="text/javascript" src="resource/js/vendor/modernizr-v2.7.1.js"></script>
+  <script type="text/javascript" src="<@siteLink path="resource/js/vendor/modernizr-v2.7.1.js"/>"></script>
 
-  <link rel="shortcut icon" href="resource/img/favicon.ico" type="image/x-icon"/>
+  <link rel="shortcut icon" href="<@siteLink path="resource/img/favicon.ico"/>" type="image/x-icon"/>
 
 <#include "analytics.ftl" />
 

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/home/home.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/home/home.ftl
@@ -25,16 +25,16 @@
 <#--The rem  polyfill rewrites the rems in to pixels. I don't think we can call this using the asset manager. -->
 <!--html5shiv. js AND respond.js - enable the use of foundation's dropdowns to work in IE8 -->
 <!--[if IE 8]>
-<script src="resource/js/vendor/rem.min.js"></script>
-<script src="resource/js/vendor/html5shiv.js"></script>
-<script src="resource/js/vendor/respond.min.js"></script>
+<script src="<@siteLink path="resource/js/vendor/rem.min.js"/>"></script>
+<script src="<@siteLink path="resource/js/vendor/html5shiv.js"/>"></script>
+<script src="<@siteLink path="resource/js/vendor/respond.min.js"/>"></script>
 <![endif]-->
 
 
 <@renderJs />
 
 <script type="text/javascript" src="https://www.google.com/jsapi?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22feeds%22%2C%22version%22%3A%221.0%22%2C%22language%22%3A%22en%22%7D%5D%7D"></script>
-<script src="resource/js/components/blogfeed.js" /></script>
+<script src="<@siteLink path="resource/js/components/blogfeed.js"/>"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Fixes a bug where the desktop homepage is viewed without a trailing slash
in the browser's address (ordinarily impossible because we 302 from there,
but may come up depending on what the web server is doing in front of us).
It would also have been a bug when the code was reused in non-homepage
contexts.
