### PR TITLE
DPRO-291: Include site key in cache key for compiled assets

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/AssetServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/AssetServiceImpl.java
@@ -80,7 +80,7 @@ public class AssetServiceImpl implements AssetService {
   @Override
   public String getCompiledAssetLink(AssetType assetType, List<String> filenames, Site site, String cacheKey)
       throws IOException {
-    String fileCacheKey = assetType.getFileCacheKey(cacheKey);
+    String fileCacheKey = site.getKey() + ":" + assetType.getFileCacheKey(cacheKey);
     String filename = cache.get(fileCacheKey);
     if (filename == null) {
       File concatenated = concatenateFiles(filenames, site, assetType.getExtension());


### PR DESCRIPTION
Fixes a bug in which cache keys become overloaded if sites share the same
path token (and are differentiated with headers). The bug is observable
only if asset minification and Memcached are both enabled.
