### PR TITLE
DPRO-240: Debug case of figures with no title

### DIFF
--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/figures.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/figures.ftl
@@ -24,7 +24,7 @@
 
       <a class="figure-link" href="figure?id=${figure.doi}">
         <img class="figure-image" src="asset?id=${figure.thumbnails.medium.file}"
-             <#if hasTitle>alt="${figure.title}"</#if>>
+             alt="<#if hasTitle>${figure.title}</#if>"> <#-- Print alt="" if no title -->
         <span class="figure-expand">Expand</span>
       </a>
 


### PR DESCRIPTION
Should fix FreeMarker errors on the figure-list page for articles that
contain such a figure.
