### PR TITLE
Set up minimal files in desktop theme for article page space

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/article.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/article.ftl
@@ -1,0 +1,20 @@
+<html>
+
+<#assign title = article.title />
+<#assign depth = 0 />
+<#include "../common/head.ftl" />
+
+<body>
+
+<#-- TODO: Global page header -->
+<#-- TODO: Article header -->
+
+<div id="articleText">
+${articleText}
+</div>
+
+<#-- TODO: Article footer -->
+<#-- TODO: Global page footer -->
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/authors.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/authors.ftl
@@ -1,0 +1,8 @@
+<#-- Placeholder! TODO: Implement -->
+<html>
+<body>
+<#list authors as author>
+<p>${author.fullName}</p>
+</#list>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comments.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comments.ftl
@@ -1,0 +1,8 @@
+<#-- Placeholder! TODO: Implement -->
+<html>
+<body>
+<#list articleComments as comment>
+<p>${comment.title}</p>
+</#list>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -1,0 +1,2965 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- 1/4/12: nlm contains xml version, we added encoding -->
+
+<!-- 1/4/12: Ambra-specific stylesheet. contains Ambra-specific templates and modified nlm templates. imports and overrides nlm. -->
+
+<!-- 1/4/12: nlm contains informational comments (system, purpose, input, output) -->
+
+<!-- 1/4/12: Ambra modifications -->
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:util="http://dtd.nlm.nih.gov/xsl/util"
+                xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:aml="http://topazproject.org/aml/"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                exclude-result-prefixes="util xsl xlink mml xs aml dc">
+
+  <!-- 1/4/12: Ambra-specific instruction. import nlm -->
+  <xsl:import href="jpub3-html.xsl"/>
+
+  <!-- 1/4/12: Ambra modifications, we output doctype statement via templates -->
+  <xsl:output doctype-public=" " doctype-system=" "
+              method="html"
+              indent="no"
+              encoding="UTF-8"
+              omit-xml-declaration="yes"/>
+
+  <!-- 1/4/12: nlm contains strip-space, preserve-space, param (css), and keys (element-by-id, xref-by-rid) -->
+
+  <!-- 1/4/12: Ambra-specific global param (pub config, passed into stylesheet from elsewhere in the pipeline) -->
+  <xsl:param name="pubAppContext"/>
+
+  <!-- ============================================================= -->
+  <!--  ROOT TEMPLATE - HANDLES HTML FRAMEWORK                       -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="make-html-header"/>
+
+  <!-- ============================================================= -->
+  <!--  TOP LEVEL                                                    -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: nlm contains template article, which calls make-article -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="sub-article | response"/>
+
+  <!-- ============================================================= -->
+  <!--  "make-article" for the document architecture                 -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template name="make-article">
+    <xsl:call-template name="newline2"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:call-template name="make-front"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:if
+        test="not((@article-type='correction') or (@article-type='retraction') or (@article-type='expression-of-concern'))">
+      <div class="articleinfo">
+        <xsl:call-template name="make-article-meta"/>
+      </div>
+    </xsl:if>
+    <xsl:call-template name="make-editors-summary"/>
+    <xsl:call-template name="newline2"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:call-template name="make-body"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:call-template name="make-back"/>
+    <xsl:call-template name="newline1"/>
+    <xsl:if
+        test="(@article-type='correction') or (@article-type='retraction') or (@article-type='expression-of-concern')">
+      <div class="articleinfo">
+        <xsl:call-template name="make-article-meta"/>
+      </div>
+      <xsl:call-template name="newline1"/>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use (we replace with make-front) -->
+  <xsl:template match="front | front-stub"/>
+
+  <!-- 1/4/12: Ambra-specific template (creates author byline, affiliations, abstracts)  -->
+  <xsl:template name="make-front">
+    <xsl:call-template name="newline1"/>
+    <!-- change context to front/article-meta -->
+    <xsl:for-each select="front/article-meta">
+      <xsl:apply-templates select="title-group" mode="metadata"/>
+      <!-- abstracts -->
+      <xsl:for-each select="abstract[not(@abstract-type) or (@abstract-type !='toc' and @abstract-type != 'teaser'
+             and @abstract-type != 'editor' and @abstract-type != 'patient')]">
+        <div class="abstract">
+          <xsl:call-template name="abstract-title"/>
+          <xsl:apply-templates select="*[not(self::title)]"/>
+        </div>
+      </xsl:for-each>
+    </xsl:for-each>
+    <xsl:call-template name="newline2"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates article metadata) -->
+  <xsl:template name="make-article-meta">
+    <xsl:for-each select="front/article-meta">
+      <!-- article citation -->
+      <p>
+        <strong>Citation:</strong>
+        <!-- authors -->
+        <xsl:for-each select="contrib-group/contrib[@contrib-type='author'][position() &lt; 7]">
+          <xsl:choose>
+            <xsl:when test="position() = 6">
+              <xsl:text>et al. </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:choose>
+                <xsl:when test="collab">
+                  <xsl:apply-templates select="collab"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <!-- 1/4/12: we'll need to adjust this when we add name-style eastern-->
+                  <xsl:apply-templates select="name/surname"/>
+                  <xsl:if test="name/given-names">
+                    <xsl:text> </xsl:text>
+                  </xsl:if>
+                  <xsl:call-template name="makeInitials">
+                    <xsl:with-param name="x">
+                      <xsl:value-of select="name/given-names"/>
+                    </xsl:with-param>
+                  </xsl:call-template>
+                  <!-- don't include the period following the suffix -->
+                  <xsl:if test="string-length(name/suffix) > 0">
+                    <xsl:text> </xsl:text>
+                    <xsl:choose>
+                      <xsl:when test="substring(name/suffix,string-length(name/suffix))='.'">
+                        <xsl:value-of select="substring(name/suffix,1,string-length(name/suffix)-1)"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:value-of select="name/suffix"/>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </xsl:if>
+                </xsl:otherwise>
+              </xsl:choose>
+              <xsl:if test="position() != last()">
+                <xsl:text>, </xsl:text>
+              </xsl:if>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+        <!-- pub year -->
+        <xsl:text> (</xsl:text>
+        <xsl:value-of select="pub-date[@pub-type='collection']/year | pub-date[@pub-type='ppub']/year"/>
+        <xsl:text>) </xsl:text>
+        <!-- article title -->
+        <xsl:apply-templates select="title-group/article-title" mode="metadata-citation"/>
+        <xsl:variable name="at" select="normalize-space(title-group/article-title)"/>
+        <!-- add a period unless there's other valid punctuation -->
+        <xsl:if
+            test="substring($at,string-length($at))!='?' and substring($at,string-length($at))!='!' and substring($at,string-length($at))!='.'">
+          <xsl:text>.</xsl:text>
+        </xsl:if>
+        <xsl:text> </xsl:text>
+        <!-- journal/volume/issue/enumber/doi -->
+        <xsl:value-of select="../journal-meta/journal-id[@journal-id-type='nlm-ta']"/>
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="volume"/>(<xsl:value-of select="issue"/>):
+        <xsl:value-of select="elocation-id"/>.
+        doi:<xsl:value-of select="article-id[@pub-id-type='doi']"/>
+      </p>
+      <!-- editors -->
+      <xsl:for-each-group select="//contrib-group/contrib[@contrib-type='editor']" group-by="role">
+        <xsl:call-template name="editors-list">
+          <xsl:with-param name="r"
+                          select="//contrib-group/contrib[@contrib-type='editor' and role=current-grouping-key()]"/>
+        </xsl:call-template>
+      </xsl:for-each-group>
+      <xsl:call-template name="editors-list">
+        <xsl:with-param name="r" select="//contrib-group/contrib[@contrib-type='editor' and not(role)]"/>
+      </xsl:call-template>
+      <!-- history/date, pub-date -->
+      <p>
+        <xsl:if test="history/date[@date-type='received']">
+          <strong>Received:</strong>
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="history/date[@date-type='received']/month" mode="map"/>
+          <xsl:text> </xsl:text>
+          <xsl:value-of select="history/date[@date-type='received']/day"/><xsl:text>, </xsl:text>
+          <xsl:value-of select="history/date[@date-type='received']/year"/><xsl:text>; </xsl:text>
+        </xsl:if>
+        <xsl:if test="history/date[@date-type='accepted']">
+          <strong>Accepted:</strong>
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="history/date[@date-type='accepted']/month" mode="map"/>
+          <xsl:text> </xsl:text>
+          <xsl:value-of select="history/date[@date-type='accepted']/day"/><xsl:text>, </xsl:text>
+          <xsl:value-of select="history/date[@date-type='accepted']/year"/><xsl:text>; </xsl:text>
+        </xsl:if>
+        <strong>Published:</strong>
+        <xsl:text> </xsl:text>
+        <xsl:apply-templates select="pub-date[@pub-type='epub']/month" mode="map"/>
+        <xsl:text> </xsl:text>
+        <xsl:if test="pub-date[@pub-type='epub']/day">
+          <xsl:value-of select="pub-date[@pub-type='epub']/day"/><xsl:text>, </xsl:text>
+        </xsl:if>
+        <xsl:value-of select="pub-date[@pub-type='epub']/year"/>
+      </p>
+      <!-- copyright -->
+      <p>
+        <xsl:choose>
+          <xsl:when test="permissions/license/license-p[contains(., 'Public Domain') or contains(., 'public domain')]">
+            <xsl:apply-templates select="permissions/license" mode="metadata"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <strong>Copyright:</strong>
+            <xsl:text> &#169; </xsl:text>
+            <xsl:apply-templates select="permissions/copyright-year"/>
+            <xsl:text> </xsl:text>
+            <xsl:apply-templates select="permissions/copyright-holder" mode="metadata"/>
+            <xsl:text>. </xsl:text>
+            <xsl:apply-templates select="permissions/license" mode="metadata"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </p>
+      <!-- Data Availability -->
+      <xsl:if test="custom-meta-group/custom-meta[@id='data-availability']">
+        <p>
+          <xsl:apply-templates select="custom-meta-group/custom-meta[@id='data-availability']/meta-value"
+                               mode="metadata"/>
+        </p>
+      </xsl:if>
+      <!-- funding statement -->
+      <xsl:if test="funding-group">
+        <p>
+          <xsl:apply-templates select="funding-group/funding-statement" mode="metadata"/>
+        </p>
+      </xsl:if>
+      <!-- competing interests -->
+      <xsl:if test="author-notes/fn[@fn-type='conflict']">
+        <p>
+          <strong>Competing interests:</strong>
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="author-notes/fn[@fn-type='conflict']"/>
+        </p>
+      </xsl:if>
+      <!-- glossary (abbreviations) -->
+      <xsl:if test="../../back/glossary">
+        <p>
+          <strong><xsl:value-of select="../..//back/glossary/title"/>:
+          </strong>
+          <xsl:for-each select="../../back/glossary/def-list/def-item">
+            <xsl:apply-templates select="term"/>,
+            <xsl:apply-templates select="def "/>
+            <xsl:if test="position() != last()">;</xsl:if>
+          </xsl:for-each>
+        </p>
+      </xsl:if>
+      <!-- end of article-meta; return to previous context -->
+    </xsl:for-each>
+    <!-- display fn-group fn-type="other" at bottom of citation -->
+    <xsl:for-each select="//back/fn-group/fn[@fn-type='other']/node()">
+      <p>
+        <xsl:apply-templates/>
+      </p>
+    </xsl:for-each>
+    <!--Fix for FEND-886-->
+    <xsl:for-each select="//front/article-meta/author-notes/fn[@fn-type='other']/node()">
+      <p>
+        <xsl:apply-templates/>
+      </p>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates editors summary) -->
+  <xsl:template name="make-editors-summary">
+    <xsl:for-each select="front/article-meta/abstract[@abstract-type='editor']">
+      <div class="editorsAbstract">
+        <xsl:call-template name="abstract-title"/>
+        <xsl:apply-templates select="*[not(self::title)]"/>
+      </div>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (replaces for-each select="body" section in nlm make-article) -->
+  <xsl:template name="make-body">
+    <xsl:for-each select="body">
+      <xsl:call-template name="newline1"/>
+      <xsl:call-template name="newline1"/>
+      <xsl:apply-templates/>
+      <xsl:call-template name="newline1"/>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="footer-metadata"/>
+
+  <!-- ============================================================= -->
+  <!--  METADATA PROCESSING                                          -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="journal-id" mode="metadata"/>
+  <xsl:template match="journal-title-group" mode="metadata"/>
+  <xsl:template match="issn" mode="metadata"/>
+  <xsl:template match="isbn" mode="metadata"/>
+  <xsl:template match="publisher" mode="metadata"/>
+  <xsl:template match="publisher-name" mode="metadata-inline"/>
+  <xsl:template match="publisher-loc" mode="metadata-inline"/>
+  <xsl:template match="notes" mode="metadata"/>
+  <xsl:template match="journal-title" mode="metadata"/>
+  <xsl:template match="journal-subtitle" mode="metadata"/>
+  <xsl:template match="trans-title-group" mode="metadata"/>
+  <xsl:template match="abbrev-journal-title" mode="metadata"/>
+  <xsl:template match="trans-title" mode="metadata"/>
+  <xsl:template match="trans-subtitle" mode="metadata"/>
+  <xsl:template match="ext-link" mode="metadata"/>
+  <xsl:template match="email" mode="metadata"/>
+  <xsl:template match="uri" mode="metadata"/>
+  <xsl:template match="self-uri" mode="metadata"/>
+  <xsl:template match="product" mode="metadata"/>
+  <xsl:template match="permissions" mode="metadata"/>
+  <xsl:template match="copyright-statement" mode="metadata"/>
+
+  <!-- 5/20/14: Ambra modifications -->
+  <xsl:template match="custom-meta-group/custom-meta[@id='data-availability']/meta-value" mode="metadata">
+    <strong>Data Availability:</strong>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="license" mode="metadata">
+    <xsl:apply-templates mode="metadata"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="license-p" mode="metadata">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="history/date" mode="metadata"/>
+  <xsl:template match="pub-date" mode="metadata"/>
+  <xsl:template name="volume-info"/>
+  <xsl:template match="volume | issue" mode="metadata-inline"/>
+  <xsl:template match="volume-id | issue-id" mode="metadata-inline"/>
+  <xsl:template match="volume-series" mode="metadata-inline"/>
+  <xsl:template match="volume" mode="metadata"/>
+  <xsl:template match="volume-id" mode="metadata"/>
+  <xsl:template match="volume-series" mode="metadata"/>
+  <xsl:template name="issue-info"/>
+  <xsl:template match="issue-title" mode="metadata-inline"/>
+  <xsl:template match="issue" mode="metadata"/>
+  <xsl:template match="issue-id" mode="metadata"/>
+  <xsl:template match="issue-title" mode="metadata"/>
+  <xsl:template match="issue-sponsor" mode="metadata"/>
+  <xsl:template match="issue-part" mode="metadata"/>
+  <xsl:template name="page-info"/>
+  <xsl:template match="elocation-id" mode="metadata"/>
+  <xsl:template match="supplement" mode="metadata"/>
+  <xsl:template match="related-article | related-object" mode="metadata"/>
+  <xsl:template match="conference" mode="metadata"/>
+  <xsl:template match="conf-date" mode="metadata"/>
+  <xsl:template match="conf-name" mode="metadata"/>
+  <xsl:template match="conf-acronym" mode="metadata"/>
+  <xsl:template match="conf-num" mode="metadata"/>
+  <xsl:template match="conf-loc" mode="metadata"/>
+  <xsl:template match="conf-sponsor" mode="metadata"/>
+  <xsl:template match="conf-theme" mode="metadata"/>
+  <xsl:template match="conf-name | conf-acronym" mode="metadata-inline"/>
+  <xsl:template match="conf-num" mode="metadata-inline"/>
+  <xsl:template match="conf-date | conf-loc" mode="metadata-inline"/>
+  <xsl:template match="article-id" mode="metadata"/>
+  <xsl:template match="award-group" mode="metadata"/>
+  <xsl:template match="funding-source" mode="metadata"/>
+  <xsl:template match="award-id" mode="metadata"/>
+  <xsl:template match="principal-award-recipient" mode="metadata"/>
+  <xsl:template match="principal-investigator" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="funding-statement" mode="metadata">
+    <strong>Funding:</strong>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="open-access" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="title-group" mode="metadata">
+    <xsl:apply-templates select="subtitle" mode="metadata"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use (article title comes from ambra) -->
+  <xsl:template match="title-group/article-title" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra-specific template (pushes article-title children, enables display of italics in citation) -->
+  <xsl:template match="title-group/article-title" mode="metadata-citation">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (part 1: fixes stray spaces in article citation, accounting for mixed element content) -->
+  <xsl:template match="title-group/article-title/node()[last()][self::text()]" mode="metadata-citation">
+    <xsl:variable name="x" select="normalize-space(concat(.,'x'))"/>
+    <xsl:value-of select="substring(normalize-space(concat('x',.)),2)"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (part 2: fixes stray spaces in article citation, accounting for mixed element content) -->
+  <!-- 1/4/12: added priority to disambiguate from "title-group/article-title" above -->
+  <xsl:template match="title-group/article-title[not(*)]" mode="metadata-citation" priority="1">
+    <xsl:value-of select="normalize-space(.)"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="title-group/subtitle" mode="metadata">
+    <h2>
+      <xsl:apply-templates/>
+    </h2>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="title-group/trans-title-group" mode="metadata"/>
+  <xsl:template match="trans-title-group/trans-title" mode="metadata"/>
+  <xsl:template match="title-group/alt-title" mode="metadata"/>
+  <xsl:template match="title-group/fn-group" mode="metadata"/>
+  <xsl:template mode="metadata" match="contrib-group"/>
+  <xsl:template name="contrib-identify"/>
+  <xsl:template match="anonymous" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="collab" mode="metadata">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (suppresses group author contributor names in author byline) -->
+  <xsl:template match="collab/contrib-group"/>
+
+  <!-- 1/4/12: Ambra modifications (formats names in author byline) -->
+  <xsl:template match="contrib/name" mode="metadata">
+    <xsl:call-template name="write-name"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates first names in author byline) -->
+  <xsl:template match="given-names" mode="contrib-abbr">
+    <xsl:call-template name="abbreviate-name">
+      <xsl:with-param name="n" select="."/>
+    </xsl:call-template>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates period after initial in given-name in author byline) -->
+  <xsl:template name="abbreviate-name">
+    <xsl:param name="n"/>
+    <xsl:variable name="x" select="normalize-space($n)"/>
+    <xsl:value-of select="$x"/>
+    <xsl:if test="substring($x,string-length($x),1) != '.' and (string-length($x) = 1
+           or (string-length($x) > 1 and substring($x,string-length($x)-1,1)=' '))">
+      <xsl:text>.</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (adds xref symbols to author byline) -->
+  <xsl:template match="name" mode="metadata-inline">
+    <xsl:apply-templates select="../xref[@ref-type='aff']" mode="metadata-inline"/>
+    <xsl:if test="../@equal-contrib='yes'">
+      <sup>
+        <a href="#equal-contrib">#</a>
+      </sup>
+    </xsl:if>
+    <xsl:apply-templates select="../xref[@ref-type='fn']" mode="metadata-inline"/>
+    <!-- if the deceased attribute is set and there isn't already a deceased footnote, output a dagger -->
+    <xsl:if
+        test="../@deceased='yes' and not(../xref/sup='‡') and not(../ref/sup='&amp;dagger;') and not(../ref/sup='&amp;Dagger;')">
+      <sup>
+        <a href="#deceased">&#x2020;</a>
+      </sup>
+    </xsl:if>
+    <xsl:apply-templates select="../xref[@ref-type='corresp']" mode="metadata-inline"/>
+    <xsl:apply-templates select="../xref[@ref-type='author-notes']" mode="metadata-inline"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="contrib-amend"/>
+  <xsl:template match="degrees" mode="metadata-inline"/>
+  <xsl:template match="xref" mode="metadata-inline"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="xref[@ref-type='author-notes']" mode="metadata-inline">
+    <xsl:choose>
+      <xsl:when test="not(.//italic) and not (.//sup)">
+        <sup>
+          <em>
+            <xsl:element name="a">
+              <xsl:attribute name="href">#<xsl:value-of select="@rid"/>
+              </xsl:attribute>
+              <xsl:apply-templates/>
+            </xsl:element>
+          </em>
+        </sup>
+      </xsl:when>
+      <xsl:when test="not(.//italic)">
+        <em>
+          <xsl:element name="a">
+            <xsl:attribute name="href">#<xsl:value-of select="@rid"/>
+            </xsl:attribute>
+            <xsl:attribute name="class">fnoteref</xsl:attribute>
+            <xsl:value-of select="sup"/>
+          </xsl:element>
+        </em>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="xref[@ref-type='corresp']" mode="metadata-inline">
+    <xsl:if test="./sup">
+      <sup>
+        <xsl:element name="a">
+          <xsl:attribute name="href">#<xsl:value-of select="@rid"/>
+          </xsl:attribute>
+          <xsl:attribute name="class">fnoteref</xsl:attribute>
+          <xsl:value-of select="sup"/>
+        </xsl:element>
+      </sup>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="xref[@ref-type='aff']" mode="metadata-inline">
+    <xsl:if test="./sup">
+      <sup>
+        <xsl:element name="a">
+          <xsl:attribute name="href">#<xsl:value-of select="@rid"/>
+          </xsl:attribute>
+          <xsl:value-of select="sup"/>
+        </xsl:element>
+      </sup>
+    </xsl:if>
+    <xsl:if test="following-sibling::xref[@ref-type='aff']">
+      <sup>,</sup>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="xref[@ref-type='fn']" mode="metadata-inline">
+    <xsl:if test="./sup">
+      <sup>
+        <xsl:element name="a">
+          <xsl:attribute name="href">#<xsl:value-of select="@rid"/>
+          </xsl:attribute>
+          <xsl:value-of select="sup"/>
+        </xsl:element>
+      </sup>
+    </xsl:if>
+    <xsl:if test="following-sibling::xref[@ref-type='fn']">
+      <sup>,</sup>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="contrib-info"/>
+  <xsl:template mode="metadata" match="address[not(addr-line) or not(*[2])]"/>
+  <xsl:template match="address" mode="metadata"/>
+  <xsl:template mode="metadata" priority="2" match="address/*"/>
+
+  <!-- 1/4/12: Ambra-specific template (part 1: fixes stray spaces in addr-line after enabling display of italics and other formatting, accounting for mixed element content) -->
+  <xsl:template match="addr-line/node()[last()][self::text()]">
+    <xsl:variable name="x" select="normalize-space(concat(.,'x'))"/>
+    <xsl:value-of select="substring(normalize-space(concat('x',.)),2)"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (part 2: fixes stray spaces in addr-line after enabling display of italics and other formatting, accounting for mixed element content) -->
+  <xsl:template match="addr-line[not(*)]">
+    <xsl:value-of select="normalize-space(.)"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="aff" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra-specific template (creates editor list in citation) -->
+  <xsl:template name="editors-list">
+    <xsl:param name="r"/>
+    <xsl:if test="$r">
+      <p>
+        <xsl:for-each select="$r">
+          <!-- for the first item, print out the role first, i.e. Editor -->
+          <xsl:if test="position()=1">
+            <strong>
+              <xsl:choose>
+                <xsl:when test="role">
+                  <xsl:value-of select="role"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  Academic Editor
+                </xsl:otherwise>
+              </xsl:choose>
+              <!-- if multiple editors, make role plural -->
+              <xsl:if test="last() > 1">s</xsl:if>
+              <xsl:text>: </xsl:text>
+            </strong>
+          </xsl:if>
+          <xsl:apply-templates select="name | collab" mode="metadata"/>
+          <xsl:apply-templates select="*[not(self::name) and not(self::collab) and not(self::xref)
+                  and not(self::degrees) and not(self::role)]" mode="metadata"/>
+          <xsl:variable name="matchto" select="xref/@rid"/>
+          <xsl:if test="../following-sibling::aff">
+            <!-- use commas between name & aff if single editor; else use parens -->
+            <xsl:choose>
+              <xsl:when test="position() = 1 and position() = last()">
+                <xsl:text>, </xsl:text>
+                <xsl:apply-templates select="../following-sibling::aff[@id=$matchto]" mode="editor-metadata"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text> (</xsl:text>
+                <xsl:apply-templates select="../following-sibling::aff[@id=$matchto]" mode="editor-metadata"/>
+                <xsl:text>)</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:if>
+          <!-- appropriately place commas and "and" -->
+          <xsl:if test="position() != last()">
+            <xsl:text>, </xsl:text>
+          </xsl:if>
+          <xsl:if test="position() = last()-1">
+            <xsl:text>and </xsl:text>
+          </xsl:if>
+        </xsl:for-each>
+      </p>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="aff" mode="editor-metadata">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates author initials in citation) -->
+  <xsl:template name="makeInitials">
+    <xsl:param name="x"/>
+    <xsl:for-each select="tokenize($x,'\s+')">
+      <xsl:choose>
+        <xsl:when test="contains(.,'-')">
+          <xsl:for-each select="tokenize(.,'-')">
+            <xsl:value-of select="substring(.,1,1)"/>
+            <xsl:if test="position()!=last()">-</xsl:if>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="substring(.,1,1)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="author-comment" mode="metadata"/>
+  <xsl:template match="bio" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications  -->
+  <xsl:template match="on-behalf-of" mode="metadata">
+    <xsl:if test="not(../following-sibling::contrib)">
+      <xsl:text>, </xsl:text>
+    </xsl:if>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="role" mode="metadata"/>
+  <xsl:template match="author-notes" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications (creates corresponding author footnote) -->
+  <xsl:template match="author-notes/corresp" mode="metadata">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use. removed author-notes/fn from list, we process independently -->
+  <xsl:template match="author-notes/p" mode="metadata"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="author-notes/fn[@fn-type='current-aff']" mode="metadata">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="author-notes/fn[@fn-type='deceased']" mode="metadata">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="author-notes/fn[@fn-type='other']" mode="metadata">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="supplementary-material" mode="metadata"/>
+  <xsl:template match="article-categories" mode="metadata"/>
+  <xsl:template match="article-categories/subj-group" mode="metadata"/>
+  <xsl:template match="subj-group" mode="metadata"/>
+  <xsl:template match="subj-group/subj-group" mode="metadata"/>
+  <xsl:template match="subj-group/subject" mode="metadata"/>
+  <xsl:template match="series-title" mode="metadata"/>
+  <xsl:template match="series-text" mode="metadata"/>
+  <xsl:template match="kwd-group" mode="metadata"/>
+  <xsl:template match="title" mode="metadata"/>
+  <xsl:template match="kwd" mode="metadata"/>
+  <xsl:template match="compound-kwd" mode="metadata"/>
+  <xsl:template match="compound-kwd-part" mode="metadata"/>
+  <xsl:template match="counts" mode="metadata"/>
+  <xsl:template mode="metadata" match="fig-count | table-count | equation-count | ref-count | page-count | word-count"/>
+  <xsl:template match="fig-count" mode="metadata-label"/>
+  <!-- nlm says table-count, must be wrong b/c duplicated below -->
+  <xsl:template match="table-count" mode="metadata-label"/>
+  <xsl:template match="equation-count" mode="metadata-label"/>
+  <xsl:template match="ref-count" mode="metadata-label"/>
+  <xsl:template match="page-count" mode="metadata-label"/>
+  <xsl:template match="word-count" mode="metadata-label"/>
+  <xsl:template mode="metadata" match="custom-meta-group"/>
+  <xsl:template match="custom-meta" mode="metadata"/>
+  <xsl:template match="meta-name | meta-value" mode="metadata-inline"/>
+
+  <!-- ============================================================= -->
+  <!--  REGULAR (DEFAULT) MODE                                       -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: Ambra-specific template (creates section numbering in body) -->
+  <xsl:template name="make-section-id">
+    <xsl:attribute name="id">
+      <xsl:value-of select="concat('section',count(preceding-sibling::sec)+1)"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template name="make-section-class">
+    <xsl:attribute name="class">section</xsl:attribute>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="body/sec">
+    <xsl:call-template name="newline1"/>
+    <div>
+      <xsl:call-template name="make-section-id"/>
+      <xsl:call-template name="make-section-class"/>
+      <xsl:if test="descendant::title[1] != ''">
+        <xsl:element name="a">
+          <xsl:attribute name="id">
+            <xsl:value-of select="@id"/>
+          </xsl:attribute>
+          <xsl:attribute name="name">
+            <xsl:value-of select="@id"/>
+          </xsl:attribute>
+          <xsl:attribute name="toc">
+            <xsl:value-of select="@id"/>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:value-of select="descendant::title[1]"/>
+          </xsl:attribute>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </div>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="sec">
+    <xsl:apply-templates/>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="*" mode="drop-title"/>
+  <xsl:template match="title | sec-meta" mode="drop-title"/>
+  <xsl:template match="app"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="ref-list" name="ref-list">
+    <div>
+      <xsl:choose>
+        <xsl:when test="not(title)">
+          <a id="refs" name="refs" toc="refs" title="References"/>
+          <h3>References</h3>
+          <xsl:call-template name="newline1"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="title"/>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:apply-templates select="p"/>
+      <ol class="references">
+        <xsl:for-each select="ref">
+          <xsl:sort data-type="number" select="label"/>
+          <li>
+            <span class="label">
+              <xsl:value-of select="label"/>.
+            </span>
+            <a>
+              <xsl:attribute name="name">
+                <xsl:value-of select="@id"/>
+              </xsl:attribute>
+              <xsl:attribute name="id">
+                <xsl:value-of select="@id"/>
+              </xsl:attribute>
+            </a>
+            <xsl:variable name="cit" select="element-citation | mixed-citation | nlm-citation"/>
+            <xsl:apply-templates select="$cit"/>
+            <xsl:text> </xsl:text>
+            <xsl:if test="$cit[@publication-type='journal']">
+              <xsl:variable name="apos">'</xsl:variable>
+              <xsl:if test="$cit/extraCitationInfo">
+                <xsl:element name="ul">
+                  <xsl:attribute name="class">find</xsl:attribute>
+                  <xsl:attribute name="data-citedArticleID">
+                    <xsl:value-of select="$cit/extraCitationInfo/@citedArticleID"/>
+                  </xsl:attribute>
+                  <xsl:if test="$cit/extraCitationInfo/@doi">
+                    <xsl:attribute name="data-doi">
+                      <xsl:value-of select="$cit/extraCitationInfo/@doi"/>
+                    </xsl:attribute>
+                  </xsl:if>
+                  <xsl:if test="$cit/extraCitationInfo/@crossRefUrl">
+                    <xsl:element name="li">
+                      <xsl:element name="a">
+                        <xsl:attribute name="href">
+                          <xsl:value-of select="$cit/extraCitationInfo/@crossRefUrl"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="target">_new</xsl:attribute>
+                        <xsl:attribute name="title">Go to article in CrossRef</xsl:attribute>
+                        View Article
+                      </xsl:element>
+                    </xsl:element>
+                  </xsl:if>
+                  <xsl:if test="$cit/extraCitationInfo/@pubMedUrl">
+                    <xsl:element name="li">
+                      <xsl:element name="a">
+                        <xsl:attribute name="href">
+                          <xsl:value-of select="$cit/extraCitationInfo/@pubMedUrl"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="target">_new</xsl:attribute>
+                        <xsl:attribute name="title">Go to article in PubMed</xsl:attribute>
+                        PubMed/NCBI
+                      </xsl:element>
+                    </xsl:element>
+                  </xsl:if>
+                  <xsl:if test="$cit/extraCitationInfo/@googleScholarUrl">
+                    <xsl:element name="li">
+                      <xsl:element name="a">
+                        <xsl:attribute name="href">
+                          <xsl:value-of select="$cit/extraCitationInfo/@googleScholarUrl"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="target">_new</xsl:attribute>
+                        <xsl:attribute name="title">Go to article in Google Scholar</xsl:attribute>
+                        Google Scholar
+                      </xsl:element>
+                    </xsl:element>
+                  </xsl:if>
+                </xsl:element>
+              </xsl:if>
+              <xsl:if test="not($cit/extraCitationInfo)">
+                <xsl:element name="ul">
+                  <xsl:attribute name="class">find-nolinks</xsl:attribute>
+                </xsl:element>
+              </xsl:if>
+            </xsl:if>
+            <xsl:if test="$cit[@publication-type!='journal']">
+              <xsl:element name="ul">
+                <xsl:attribute name="class">find-nolinks</xsl:attribute>
+              </xsl:element>
+            </xsl:if>
+          </li>
+        </xsl:for-each>
+      </ol>
+    </div>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="sec-meta"/>
+  <xsl:template match="sec-meta/contrib-group"/>
+  <xsl:template match="sec-meta/kwd-group"/>
+
+  <!-- ============================================================= -->
+  <!--  Titles                                                       -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: MAIN TITLE TEMPLATES  -->
+
+  <!-- 1/4/12: suppress, we don't use. removed abstract/title, body/*/title, back[not(title)]/*/title from list (we process independently) -->
+  <xsl:template name="main-title" match="back/title"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="abstract/title">
+    <xsl:call-template name="newline1"/>
+    <h2>
+      <xsl:apply-templates/>
+    </h2>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates main level section headings) -->
+  <xsl:template match="body/sec/title">
+    <!-- only output an h3 if the body/sec/title has content -->
+    <xsl:if test="string(.)">
+      <h3>
+        <xsl:apply-templates/>
+      </h3>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: SECTION TITLE TEMPLATES -->
+
+  <!-- 1/4/12: suppress, we don't use. removed abstract/sec/title, body/*/*/title, back[not(title)]/*/*/title from list (we process independently) -->
+  <xsl:template name="section-title" match="back[title]/*/title"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="abstract/sec/title">
+    <xsl:call-template name="newline1"/>
+    <!-- only output an h3 if the abstract title has content -->
+    <xsl:if test="string-length() &gt; 0">
+      <h3>
+        <xsl:apply-templates/>
+      </h3>
+    </xsl:if>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template name="abstract-title">
+    <xsl:variable name="idx" select="count(preceding-sibling::abstract)"/>
+    <xsl:variable name="abs_id">abstract<xsl:value-of select="$idx"/>
+    </xsl:variable>
+    <xsl:choose>
+      <!-- if there's a title, use it -->
+      <xsl:when test="title">
+        <xsl:element name="a">
+          <xsl:attribute name="id">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="name">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="toc">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="title">
+            <xsl:value-of select="title"/>
+          </xsl:attribute>
+        </xsl:element>
+        <xsl:apply-templates select="title"/>
+      </xsl:when>
+      <!-- if there's no title, create one -->
+      <xsl:when test="self::abstract">
+        <xsl:element name="a">
+          <xsl:attribute name="id">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="name">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="toc">
+            <xsl:value-of select="$abs_id"/>
+          </xsl:attribute>
+          <xsl:attribute name="title">Abstract</xsl:attribute>
+        </xsl:element>
+        <h2>
+          <xsl:text>Abstract</xsl:text>
+        </h2>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates article second-level heading) -->
+  <xsl:template match="body/sec/sec/title">
+    <xsl:call-template name="newline1"/>
+    <h4>
+      <xsl:apply-templates/>
+    </h4>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: SUBSECTION TITLES -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="subsection-title"
+                match="abstract/*/*/title | back[title]/*/*/title | back[not(title)]/*/*/*/title"/>
+
+  <!-- 1/4/12: Ambra-specific template (creates article third-level heading) -->
+  <xsl:template match="body/sec/sec/sec/title">
+    <h5>
+      <xsl:apply-templates/>
+      <xsl:call-template name="punctuation"/>
+    </h5>
+  </xsl:template>
+
+  <!-- 1/4/12: BLOCK AND MISC TITLES -->
+
+  <!-- 1/4/12: suppress, we don't use. removed boxed-text/title from list (we process independently) -->
+  <xsl:template name="block-title" priority="2"
+                match="list/title | def-list/title | boxed-text/title | verse-group/title | glossary/title | kwd-group/title"/>
+
+  <!-- 1/12/12: Ambra-specific template -->
+  <xsl:template match="ack/sec/title">
+    <xsl:call-template name="newline1"/>
+    <h4>
+      <xsl:apply-templates/>
+    </h4>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="ref-list[not(ancestor::back)]/title">
+    <a>
+      <xsl:attribute name="id">
+        <xsl:value-of select="replace(lower-case(.),' ','')"/>
+      </xsl:attribute>
+      <xsl:attribute name="name">
+        <xsl:value-of select="replace(lower-case(.),' ','')"/>
+      </xsl:attribute>
+    </a>
+    <h3>
+      <xsl:apply-templates/>
+    </h3>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="back/ref-list/title">
+    <a>
+      <xsl:attribute name="id">
+        <xsl:value-of select="replace(lower-case(.),' ','')"/>
+      </xsl:attribute>
+      <xsl:attribute name="name">
+        <xsl:value-of select="replace(lower-case(.),' ','')"/>
+      </xsl:attribute>
+      <xsl:attribute name="toc">
+        <xsl:value-of select="replace(lower-case(.),' ','')"/>
+      </xsl:attribute>
+      <xsl:attribute name="title">
+        <xsl:choose>
+          <xsl:when test="string-length(.) &gt; 0">
+            <xsl:value-of select="."/>
+          </xsl:when>
+          <xsl:otherwise>
+            References
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    </a>
+    <h3>
+      <xsl:apply-templates/>
+    </h3>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="notes/sec/title">
+    <h3>
+      <xsl:value-of select="."/>
+    </h3>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications (creates any other titles not already specified) -->
+  <xsl:template match="title">
+    <xsl:choose>
+      <!-- if there's a title, use it -->
+      <xsl:when test="count(ancestor::sec) > 1">
+        <xsl:call-template name="newline1"/>
+        <h4>
+          <xsl:apply-templates/>
+        </h4>
+        <xsl:call-template name="newline1"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="newline1"/>
+        <h3>
+          <xsl:apply-templates/>
+        </h3>
+        <xsl:call-template name="newline1"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="subtitle"/>
+
+  <!-- ============================================================= -->
+  <!--  Figures, lists and block-level objects                       -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="address"/>
+  <xsl:template name="address-line"/>
+  <xsl:template match="address/*"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="alternatives">
+    <xsl:apply-templates select="graphic"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template
+      match="array | disp-formula-group | fig-group | fn-group | license | long-desc | open-access | sig-block | table-wrap-foot | table-wrap-group"/>
+  <xsl:template match="attrib"/>
+
+  <!-- 1/4/12: suppress, we don't use (removed fig, table-wrap, and boxed-text here, process them independently) -->
+  <xsl:template match="chem-struct-wrap"/>
+
+  <!-- 1/4/12: Ambra-specific template (creates box for figs/tables within article body, creates slideshow window) -->
+  <xsl:template match="fig | table-wrap">
+    <xsl:variable name="figId">
+      <xsl:value-of select="@id"/>
+    </xsl:variable>
+    <xsl:variable name="apos">'</xsl:variable>
+    <!-- Fix here for AMEC-2351 only pick graphic nodes that are immediate children of the fig or table-wrap nodes -->
+    <xsl:if test="./graphic|./alternatives/graphic">
+      <xsl:variable name="imageURI">
+        <xsl:value-of select="(./graphic|./alternatives/graphic)/@xlink:href"/>
+      </xsl:variable>
+      <xsl:variable name="slideshowURL">
+        <xsl:value-of select="concat($pubAppContext, '/article/fetchObject.action?uri=',
+                  $imageURI,'&amp;representation=PNG_M')"/>
+      </xsl:variable>
+
+      <xsl:variable name="pptURL">
+        <xsl:value-of select="concat('/article/',$imageURI, '/powerpoint')"/>
+      </xsl:variable>
+
+      <xsl:variable name="bigImgURL">
+        <xsl:value-of select="concat('/article/',$imageURI,'/largerimage')"/>
+      </xsl:variable>
+      <xsl:variable name="bigImgDOI">
+        <xsl:value-of select="concat($imageURI,'.PNG_L')"/>
+      </xsl:variable>
+
+      <xsl:variable name="origImgURL">
+        <xsl:value-of select="concat('/article/',$imageURI,'/originalimage')"/>
+      </xsl:variable>
+      <xsl:variable name="origImgDOI">
+        <xsl:value-of select="concat($imageURI,'.TIF')"/>
+      </xsl:variable>
+
+      <xsl:variable name="targetURI">
+        <!-- for corrections figure doi ending in ".xnnn.cn" instead of ".xnnn" -->
+        <xsl:choose>
+          <xsl:when test="ends-with($imageURI,'.cn')">
+            <xsl:value-of select="substring($imageURI, 1, (string-length($imageURI)-8))"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="substring($imageURI, 1, (string-length($imageURI)-5))"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <div class="figure">
+        <!--id needs to be attached to "figure" div for proper anchor linking-->
+        <xsl:attribute name="id">
+          <xsl:value-of select="translate($figId, '.', '-')"/>
+        </xsl:attribute>
+        <div class="img">
+          <xsl:element name="a">
+            <!-- 6/13/12: added translate so names and ids have dash (for figure enhancement) -->
+            <xsl:attribute name="name">
+              <xsl:value-of select="translate($figId, '.', '-')"/>
+            </xsl:attribute>
+            <xsl:attribute name="title">Click for larger image</xsl:attribute>
+            <xsl:attribute name="href">
+              <xsl:value-of select="$slideshowURL"/>
+            </xsl:attribute>
+            <xsl:attribute name="data-doi">
+              <xsl:value-of select="$targetURI"/>
+            </xsl:attribute>
+            <xsl:attribute name="data-uri">
+              <xsl:value-of select="$imageURI"/>
+            </xsl:attribute>
+            <xsl:element name="img">
+              <xsl:attribute name="src">
+                <xsl:value-of
+                    select="concat($pubAppContext,'/article/fetchObject.action?uri=',$imageURI,'&amp;representation=PNG_I')"/>
+              </xsl:attribute>
+              <xsl:attribute name="alt">thumbnail</xsl:attribute>
+              <xsl:attribute name="class">thumbnail</xsl:attribute>
+            </xsl:element>
+          </xsl:element>
+        </div>
+        <!--start figure download-->
+        <div class="figure-inline-download">
+          Download:
+          <ul>
+            <li>
+              <div class="icon">
+                <xsl:element name="a">
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="$pptURL"/>
+                  </xsl:attribute>
+                  PPT
+                </xsl:element>
+              </div>
+              <xsl:element name="a">
+                <xsl:attribute name="href">
+                  <xsl:value-of select="$pptURL"/>
+                </xsl:attribute>
+                PowerPoint slide
+              </xsl:element>
+            </li>
+            <li>
+              <div class="icon">
+                <xsl:element name="a">
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="$bigImgURL"/>
+                  </xsl:attribute>
+                  PNG
+                </xsl:element>
+              </div>
+              <xsl:element name="a">
+                <xsl:attribute name="href">
+                  <xsl:value-of select="$bigImgURL"/>
+                </xsl:attribute>
+                larger image
+                (
+                <xsl:element name="span">
+                  <xsl:attribute name="id">
+                    <xsl:value-of select="$bigImgDOI"/>
+                  </xsl:attribute>
+                </xsl:element>
+                )
+              </xsl:element>
+            </li>
+            <li>
+              <div class="icon">
+                <xsl:element name="a">
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="$origImgURL"/>
+                  </xsl:attribute>
+                  TIFF
+                </xsl:element>
+              </div>
+              <xsl:element name="a">
+                <xsl:attribute name="href">
+                  <xsl:value-of select="$origImgURL"/>
+                </xsl:attribute>
+                original image
+                (
+                <xsl:element name="span">
+                  <xsl:attribute name="id">
+                    <xsl:value-of select="$origImgDOI"/>
+                  </xsl:attribute>
+                </xsl:element>
+                )
+              </xsl:element>
+            </li>
+          </ul>
+        </div>
+        <!--end figure download-->
+        <p>
+          <strong>
+            <xsl:apply-templates select="label"/>
+            <xsl:if test="caption/title">
+              <xsl:text> </xsl:text>
+              <span>
+                <xsl:apply-templates select="caption/title"/>
+              </span>
+            </xsl:if>
+          </strong>
+        </p>
+        <xsl:apply-templates select="caption/node()[not(self::title)]"/>
+        <xsl:if test="object-id[@pub-id-type='doi']">
+          <span>
+            <xsl:apply-templates select="object-id[@pub-id-type='doi']"/>
+          </span>
+        </xsl:if>
+      </div>
+    </xsl:if>
+    <xsl:if test="not(.//graphic)">
+      <xsl:if test=".//table">
+        <div class="table-wrap">
+          <xsl:attribute name="name">
+            <xsl:value-of select="$figId"/>
+          </xsl:attribute>
+          <xsl:attribute name="id">
+            <xsl:value-of select="$figId"/>
+          </xsl:attribute>
+          <a>
+            <xsl:attribute name="name">
+              <xsl:value-of select="$figId"/>
+            </xsl:attribute>
+          </a>
+          <div class="expand">
+            <xsl:attribute name="onclick">
+              return tableOpen(<xsl:value-of select="concat($apos, $figId, $apos)"/>, "HTML");
+            </xsl:attribute>
+          </div>
+          <div class="table">
+            <xsl:apply-templates select=".//table"/>
+          </div>
+          <p class="caption">
+            <xsl:apply-templates select="label"/>
+            <xsl:if test="caption/title">
+              <xsl:text> </xsl:text>
+              <span>
+                <xsl:apply-templates select="caption/title"/>
+              </span>
+            </xsl:if>
+          </p>
+          <xsl:apply-templates select="caption/node()[not(self::title)]"/>
+          <xsl:if test="table-wrap-foot">
+            <xsl:for-each select="table-wrap-foot//fn">
+              <div class="table-footnote">
+                <span class="fn-label">
+                  <xsl:value-of select="label"/>
+                </span>
+                <span class="fn-text">
+                  <xsl:apply-templates select="p"/>
+                </span>
+              </div>
+            </xsl:for-each>
+          </xsl:if>
+          <div class="table-download">
+            <div class="icon">
+              <xsl:attribute name="onclick">
+                return tableOpen(<xsl:value-of select="concat($apos, $figId, $apos)"/>, "CSV");
+              </xsl:attribute>
+              CSV
+            </div>
+            <a class="label">
+              <xsl:attribute name="onclick">
+                return tableOpen(<xsl:value-of select="concat($apos, $figId, $apos)"/>, "CSV");
+              </xsl:attribute>
+              Download CSV
+            </a>
+          </div>
+        </div>
+      </xsl:if>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="boxed-text">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:element name="div">
+      <xsl:attribute name="class">box</xsl:attribute>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="caption">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="caption/title">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use (removed disp-formula here, handle it separately) -->
+  <xsl:template match="statement"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="disp-formula">
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <!-- span class='equation' goes around equations -->
+    <span class="equation">
+      <xsl:apply-templates select="*[not(self::label)]"/>
+      <xsl:apply-templates select="label"/>
+    </span>
+    <br/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="glossary"/>
+  <xsl:template match="textual-form"/>
+  <xsl:template match="glossary/glossary"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="graphic | inline-graphic">
+    <xsl:element name="img">
+      <xsl:if test="@xlink:href">
+        <xsl:variable name="graphicDOI">
+          <xsl:value-of select="@xlink:href"/>
+        </xsl:variable>
+        <xsl:attribute name="src">
+          <xsl:value-of
+              select="concat($pubAppContext,'/article/fetchObject.action?uri=',$graphicDOI,'&amp;representation=PNG')"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:attribute name="class">
+        <xsl:value-of>inline-graphic</xsl:value-of>
+      </xsl:attribute>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- 1/4/12: nlm contains alt-text (suppressed here, processed within graphic|inline-graphic) -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="list">
+    <xsl:call-template name="newline1"/>
+    <xsl:choose>
+      <xsl:when test="@list-type='bullet'">
+        <xsl:call-template name="newline1"/>
+        <ul class="bulletlist">
+          <xsl:call-template name="newline1"/>
+          <xsl:apply-templates/>
+          <xsl:call-template name="newline1"/>
+        </ul>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="newline1"/>
+        <ol class="{@list-type}">
+          <xsl:call-template name="newline1"/>
+          <xsl:apply-templates/>
+          <xsl:call-template name="newline1"/>
+        </ol>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template priority="2" mode="list" match="list[@list-type='simple' or list-item/label]"/>
+  <xsl:template match="list[@list-type='bullet' or not(@list-type)]" mode="list"/>
+  <xsl:template match="list" mode="list"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="list-item">
+    <xsl:call-template name="newline1"/>
+    <li>
+      <xsl:if test="../@prefix-word">
+        <xsl:value-of select="../@prefix-word"/>
+        <xsl:text> </xsl:text>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </li>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="list-item/label">
+    <span class="list-label">
+      <xsl:apply-templates/>
+      <xsl:text>. </xsl:text>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="media"/>
+  <xsl:template match="license-p"/>
+  <!-- 1/4/12: removed p from list, we process independently -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <!--if this changes, the two templates below, "preSiClass", and "postSiClass" have to change, too-->
+  <xsl:template match="p">
+    <a>
+      <xsl:call-template name="makeIdNameFromXpathLocation"/>
+    </a>
+    <p>
+      <xsl:apply-templates/>
+    </p>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!--3/1/13, add class to a specific paragraph for after styling-->
+  <!--note that if 'match="p"' changes, this will have to change-->
+  <xsl:template name="preSiClass">
+    <a>
+      <xsl:call-template name="makeIdNameFromXpathLocation"/>
+    </a>
+    <p class="preSiDOI">
+      <xsl:apply-templates/>
+    </p>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!--3/4/13 add class to paragraphs appearing after doi in supplementary doi-->
+  <!--for styling-->
+  <xsl:template name="postSiClass">
+    <a>
+      <xsl:call-template name="makeIdNameFromXpathLocation"/>
+    </a>
+    <p class="postSiDOI">
+      <xsl:apply-templates/>
+    </p>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="@content-type"/>
+
+  <!-- 1/4/12: Ambra-specific template (overrides nlm list-item/p[not(preceding-sibling::*[not(self::label)])]) -->
+  <xsl:template match="list-item/p">
+    <xsl:apply-templates/>
+    <xsl:if test="following-sibling::p">
+      <br/>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: nlm contains list-item/p[not(preceding-sibling::*[not(self::label)])]". we override with list-item/label, can't suppress, causes p to disappear -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="product"/>
+  <xsl:template match="permissions"/>
+  <xsl:template match="copyright-statement"/>
+  <xsl:template match="def-list"/>
+  <xsl:template match="def-item"/>
+
+  <!-- 1/4/12: Ambra-specific template (creates def-list in the body, differs from def-list in metadata glossary) -->
+  <xsl:template match="body//def-list">
+    <dl>
+      <xsl:for-each select="def-item">
+        <dt>
+          <xsl:apply-templates select="term"/>
+        </dt>
+        <dd>
+          <xsl:apply-templates select="def"/>
+        </dd>
+      </xsl:for-each>
+    </dl>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="def-item//p">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="def-item//named-content">
+    <span class="{@content-type}">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="def-item//sup | def-item//sub | def-item//em | def-item//strong">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="term">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="def">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="disp-quote">
+    <xsl:call-template name="newline1"/>
+    <blockquote>
+      <xsl:call-template name="assign-id"/>
+      <xsl:apply-templates/>
+    </blockquote>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="preformat">
+    <pre>
+      <xsl:call-template name="assign-id"/>
+      <xsl:apply-templates/>
+    </pre>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="ref"/>
+  <xsl:template match="ref/*" priority="-1"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="mixed-citation">
+    <xsl:apply-templates/>
+    <xsl:if test="extraCitationInfo/@doi and not(ext-link) and not(comment/ext-link)">
+      doi:
+      <xsl:value-of select="extraCitationInfo/@doi"/>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (formats mixed-citation names, most mixed-citation formatting is in the xml) -->
+  <xsl:template match="mixed-citation/name">
+    <xsl:apply-templates select="surname"/>
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates select="given-names"/>
+    <xsl:if test="suffix">
+      <xsl:text> </xsl:text>
+      <xsl:apply-templates select="suffix"/>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific templates for legacy references (element-citation: journal/no citation, book/other, supporting templates -->
+
+  <!-- 6/8/12: Ambra-specific template: legacy nlm-citation references (need separate transform to account for different tag order) -->
+  <xsl:template match="nlm-citation">
+    <xsl:apply-templates select="person-group" mode="book"/>
+    <xsl:apply-templates select="collab" mode="book"/>
+    <xsl:apply-templates select="year" mode="none"/>
+    <xsl:apply-templates select="article-title" mode="none"/>
+    <xsl:apply-templates select="*[not(self::annotation) and not(self::edition) and not(self::person-group)
+        and not(self::collab) and not(self::comment) and not(self::year) and not (self::article-title)]|text()"
+                         mode="none"/>
+    <xsl:call-template name="citationComment"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template: legacy references (publication-type journal and no publication-type) -->
+  <xsl:template match="element-citation">
+    <xsl:apply-templates select="person-group" mode="book"/>
+    <xsl:apply-templates select="collab" mode="book"/>
+    <xsl:apply-templates
+        select="*[not(self::edition) and not(self::person-group) and not(self::collab) and not(self::comment)] | text()"
+        mode="none"/>
+    <xsl:call-template name="citationComment"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template: legacy references (publication-types book and other) -->
+  <!-- 6/23/12: add nlm-citation and page-count for nlm-citation-->
+  <xsl:template match="element-citation[@publication-type='book'] | element-citation[@publication-type='other'] |
+                         nlm-citation[@publication-type='book'] | nlm-citation[@publication-type='other']">
+    <xsl:variable name="augroupcount" select="count(person-group) + count(collab)"/>
+    <xsl:choose>
+      <!-- chapter in edited book -->
+      <xsl:when test="$augroupcount>1 and person-group[@person-group-type!='author'] and article-title">
+        <xsl:apply-templates select="person-group[@person-group-type='author']" mode="book"/>
+        <xsl:apply-templates select="collab" mode="book"/>
+        <xsl:apply-templates select="year | month" mode="book"/>
+        <xsl:apply-templates select="article-title" mode="editedbook"/>
+        <xsl:text> In:</xsl:text>
+        <xsl:apply-templates select="person-group[@person-group-type='editor']" mode="book"/>
+        <xsl:apply-templates select="source" mode="book"/>
+        <xsl:apply-templates select="edition" mode="book"/>
+        <xsl:apply-templates select="volume" mode="book"/>
+        <xsl:apply-templates select="publisher-name | publisher-loc" mode="none"/>
+        <xsl:apply-templates select="fpage | lpage" mode="book"/>
+        <xsl:apply-templates select="size | page-count" mode="book"/>
+      </xsl:when>
+      <!-- when person-group without pgtype exists -->
+      <xsl:when test="person-group[not(@person-group-type)]">
+        <xsl:apply-templates select="person-group" mode="book"/>
+        <xsl:apply-templates select="collab" mode="book"/>
+        <xsl:apply-templates select="year | month" mode="book"/>
+        <xsl:apply-templates select="article-title" mode="book"/>
+        <xsl:apply-templates select="source" mode="book"/>
+        <xsl:apply-templates select="edition" mode="book"/>
+        <xsl:apply-templates select="person-group[@person-group-type='editor']" mode="book"/>
+        <xsl:apply-templates select="volume" mode="book"/>
+        <xsl:apply-templates select="issue" mode="none"/>
+        <xsl:apply-templates select="publisher-name | publisher-loc" mode="none"/>
+        <xsl:apply-templates select="fpage | lpage" mode="book"/>
+        <xsl:apply-templates select="size | page-count" mode="book"/>
+      </xsl:when>
+      <!-- when pgtype author exists but not chapter in edited book -->
+      <xsl:when test="person-group[@person-group-type='author']">
+        <xsl:apply-templates select="person-group[@person-group-type='author']" mode="book"/>
+        <xsl:apply-templates select="collab" mode="book"/>
+        <xsl:apply-templates select="year | month" mode="book"/>
+        <xsl:apply-templates select="article-title" mode="book"/>
+        <xsl:apply-templates select="source" mode="book"/>
+        <xsl:apply-templates select="edition" mode="book"/>
+        <xsl:apply-templates select="person-group[@person-group-type='editor']" mode="book"/>
+        <xsl:apply-templates select="volume" mode="book"/>
+        <xsl:apply-templates select="issue" mode="none"/>
+        <xsl:apply-templates select="publisher-name | publisher-loc" mode="none"/>
+        <xsl:apply-templates select="fpage | lpage" mode="book"/>
+        <xsl:apply-templates select="size | page-count" mode="book"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- all others -->
+        <xsl:apply-templates select="person-group[@person-group-type='editor']" mode="book"/>
+        <xsl:apply-templates select="collab" mode="book"/>
+        <xsl:apply-templates select="year | month" mode="book"/>
+        <xsl:apply-templates select="article-title" mode="book"/>
+        <xsl:apply-templates select="source" mode="book"/>
+        <xsl:apply-templates select="edition" mode="book"/>
+        <xsl:apply-templates select="volume" mode="book"/>
+        <xsl:apply-templates select="issue" mode="none"/>
+        <xsl:apply-templates select="publisher-name | publisher-loc" mode="none"/>
+        <xsl:apply-templates select="fpage | lpage" mode="book"/>
+        <xsl:apply-templates select="size | page-count" mode="book"/>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:call-template name="citationComment"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="year" mode="none">
+    <xsl:choose>
+      <xsl:when test="../month">
+        <xsl:apply-templates mode="none"/>
+        <xsl:text> </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text> (</xsl:text>
+        <xsl:apply-templates mode="none"/>
+        <xsl:text>) </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <!-- 6/8/12: comment out call-template: don't need? -->
+  <xsl:template match="article-title" mode="none">
+    <xsl:apply-templates/>
+    <!--<xsl:call-template name="punctuation" />  -->
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="source" mode="none">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:choose>
+      <xsl:when test="../volume | ../fpage">
+        <xsl:if test="../edition">
+          <xsl:text> (</xsl:text>
+          <xsl:apply-templates select="../edition" mode="book"/>
+          <xsl:text>)</xsl:text>
+        </xsl:if>
+        <xsl:text> </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:if test="../edition">
+          <xsl:text> (</xsl:text>
+          <xsl:apply-templates select="../edition" mode="book"/>
+          <xsl:text>)</xsl:text>
+        </xsl:if>
+        <xsl:text>. </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="volume" mode="none">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:if test="not(../issue)">
+      <xsl:text>: </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="issue" mode="none">
+    <xsl:if test="not(starts-with(normalize-space(),'('))">
+      <xsl:text>(</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates/>
+    <xsl:if test="not(ends-with(normalize-space(),')'))">
+      <xsl:text>)</xsl:text>
+    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="../fpage or ../lpage or ../elocation-id">
+        <xsl:text>: </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>.</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="elocation-id" mode="none">
+    <xsl:apply-templates/>
+    <xsl:text>. </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="fpage" mode="none">
+    <xsl:apply-templates/>
+    <xsl:choose>
+      <xsl:when test="following-sibling::lpage[1]">
+        <xsl:text>&#8211;</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>.</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="lpage" mode="none">
+    <xsl:apply-templates/>
+    <xsl:text>.</xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="publisher-loc" mode="none">
+    <xsl:apply-templates/>
+    <xsl:choose>
+      <xsl:when test="not(following-sibling::*)">
+        <xsl:text>.</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>: </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="publisher-name" mode="none">
+    <xsl:apply-templates/>
+    <xsl:text>. </xsl:text>
+  </xsl:template>
+
+  <!-- 6/8/12: Ambra-specific template (replicate mode book as mode none for citations without publication-type) -->
+  <xsl:template match="size" mode="none">
+    <xsl:apply-templates/>
+    <xsl:text> p.</xsl:text>
+    <xsl:if test="following-sibling::*">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 6/12/12: Ambra-specific template (replicate size but use page-count for nlm-citation) -->
+  <xsl:template match="page-count" mode="none">
+    <xsl:apply-templates select="@count"/>
+    <xsl:text> p.</xsl:text>
+    <xsl:if test="following-sibling::*">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="person-group" mode="book">
+    <xsl:apply-templates mode="book"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="person-group[@person-group-type='editor']" mode="book">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates mode="book"/>
+    <xsl:choose>
+      <xsl:when test="count(name) > 1">
+        <xsl:text>, editors. </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>, editor. </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="name" mode="book">
+    <xsl:apply-templates select="surname"/>
+    <xsl:text> </xsl:text>
+    <xsl:if test="given-names">
+      <xsl:apply-templates select="given-names"/>
+      <xsl:if test="suffix">
+        <xsl:text> </xsl:text>
+        <xsl:apply-templates select="suffix"/>
+      </xsl:if>
+    </xsl:if>
+    <!-- punctuation after name -->
+    <xsl:choose>
+      <xsl:when test="../following-sibling::collab">
+        <xsl:text>, </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:choose>
+          <xsl:when test="position()=last()"></xsl:when>
+          <xsl:otherwise>,</xsl:otherwise>
+        </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="collab" mode="book">
+    <xsl:apply-templates/>
+    <xsl:if test="following-sibling::collab">
+      <xsl:text>, </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="etal" mode="book">
+    <xsl:text>et al.</xsl:text>
+    <xsl:choose>
+      <xsl:when test="parent::person-group/@person-group-type">
+        <xsl:choose>
+          <xsl:when test="parent::person-group/@person-group-type='author'">
+            <xsl:text> </xsl:text>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text> </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="year" mode="book">
+    <xsl:choose>
+      <xsl:when test="../month">
+        <xsl:apply-templates/>
+        <xsl:text> </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text> (</xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>) </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="month" mode="book">
+    <xsl:variable name="month" select="."/>
+    <xsl:choose>
+      <xsl:when test="$month='01' or $month='1' or $month='January'">Jan</xsl:when>
+      <xsl:when test="$month='02' or $month='2' or $month='February'">Feb</xsl:when>
+      <xsl:when test="$month='03' or $month='3' or $month='March'">Mar</xsl:when>
+      <xsl:when test="$month='04' or $month='4' or $month='April'">Apr</xsl:when>
+      <xsl:when test="$month='05' or $month='5' or $month='May'">May</xsl:when>
+      <xsl:when test="$month='06' or $month='6' or $month='June'">Jun</xsl:when>
+      <xsl:when test="$month='07' or $month='7' or $month='July'">Jul</xsl:when>
+      <xsl:when test="$month='08' or $month='8' or $month='August'">Aug</xsl:when>
+      <xsl:when test="$month='09' or $month='9' or $month='September'">Sep</xsl:when>
+      <xsl:when test="$month='10' or $month='October'">Oct</xsl:when>
+      <xsl:when test="$month='11' or $month='November'">Nov</xsl:when>
+      <xsl:when test="$month='12' or $month='December'">Dec</xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$month"/>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:if test="../day">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="../day"/>
+    </xsl:if>
+    <xsl:text>. </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="article-title" mode="book">
+    <xsl:apply-templates/>
+    <xsl:call-template name="punctuation"/>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="article-title" mode="editedbook">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:call-template name="punctuation"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="source" mode="book">
+    <xsl:apply-templates/>
+    <xsl:call-template name="punctuation"/>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="volume | edition" mode="book">
+    <xsl:apply-templates/>
+    <xsl:text>. </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="fpage" mode="book">
+    <xsl:if test="../lpage">
+      <!-- handle old journal articles that were coded as type other, but actually had a volume, source and page numbers -->
+      <xsl:choose>
+        <xsl:when test="name(preceding-sibling::node()[1])='volume'">
+          <xsl:text>: </xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>pp. </xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:apply-templates/>
+      <xsl:text>&#8211;</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="lpage" mode="book">
+    <xsl:if test="../fpage">
+      <xsl:apply-templates/>
+      <xsl:text>.</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="size" mode="book">
+    <xsl:apply-templates/>
+    <xsl:text> p.</xsl:text>
+    <xsl:if test="following-sibling::*">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 6/23/12: Ambra-specific template (replicate size but use page-count for nlm-citation types book/other) -->
+  <xsl:template match="page-count" mode="book">
+    <xsl:apply-templates select="@count"/>
+    <xsl:text> p.</xsl:text>
+    <xsl:if test="following-sibling::*">
+      <xsl:text> </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 6/8/12: Ambra-specific template -->
+  <xsl:template match="comment">
+    <xsl:if test="not(self::node()='.')">
+      <xsl:text> </xsl:text>
+      <xsl:apply-templates/>
+      <xsl:if test="substring(.,string-length(.)) != '.' and not(ends-with(..,'.'))">
+        <xsl:text>. </xsl:text>
+      </xsl:if>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template name="citationComment">
+    <!-- only output a single comment tag that appears as the very last child of the citation -->
+    <xsl:variable name="x" select="child::comment[position()=last()]"/>
+    <xsl:if test="not(starts-with($x,'p.')) and not(starts-with($x,'In:') and not(starts-with($x,'pp.')))">
+      <xsl:text> </xsl:text>
+      <xsl:apply-templates select="$x"/>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: end legacy reference section -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="ref/note" priority="2"/>
+  <xsl:template
+      match="app/related-article | app-group/related-article | bio/related-article | body/related-article | boxed-text/related-article | disp-quote/related-article | glossary/related-article | ref-list/related-article | sec/related-article"/>
+  <xsl:template
+      match="app/related-object | app-group/related-object | bio/related-object | body/related-object | boxed-text/related-object | disp-quote/related-object | glossary/related-object | ref-list/related-object | sec/related-object"/>
+  <xsl:template match="speech"/>
+  <!-- 1/4/12: speech/speaker mode speech already suppressed in nlm -->
+  <xsl:template match="speech/p" mode="speech"/>
+  <xsl:template match="speech/speaker"/>
+
+  <!-- 1/7/13: Ambra modifications for figshare widget, FEND-2  -->
+  <xsl:template match="supplementary-material[1]">
+    <xsl:element name="div">
+      <xsl:attribute name="class">figshare_widget</xsl:attribute>
+      <xsl:attribute name="doi">
+        <xsl:value-of select="//article/front/article-meta/article-id[@pub-id-type='doi']"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:call-template name="supplementary-material"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="supplementary-material" name="supplementary-material">
+    <xsl:variable name="the-label">
+      <xsl:choose>
+        <xsl:when test="label">
+          <xsl:value-of select="label"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>Supplementary Material</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:element name="a">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:element>
+    <xsl:variable name="objURI">
+      <xsl:value-of select="@xlink:href"/>
+    </xsl:variable>
+    <p class="siTitle">
+      <strong>
+        <xsl:element name="a">
+          <xsl:attribute name="href">
+            <xsl:value-of select="concat($pubAppContext,'/article/fetchSingleRepresentation.action?uri=',$objURI)"/>
+          </xsl:attribute>
+          <xsl:apply-templates select="label"/>
+        </xsl:element>
+        <xsl:apply-templates select="caption/title"/>
+      </strong>
+    </p>
+
+    <!--here, we're appending SI DOI after the caption but before the file type-->
+    <xsl:variable name="siDOI">
+      <xsl:value-of select="replace($objURI,'info:doi/','doi:')"/>
+    </xsl:variable>
+
+    <xsl:choose>
+
+      <!--If one or no caption/p, insert doi-->
+      <xsl:when test="count(caption/p) &lt; 2">
+        <!--doi-->
+        <p class="siDoi">
+          <xsl:value-of select="$siDOI"/>
+        </p>
+        <!--add class to target styling-->
+        <xsl:for-each select="caption/p">
+          <xsl:call-template name="postSiClass"/>
+        </xsl:for-each>
+      </xsl:when>
+
+      <!--if 2 caption/p elements, each needs it's own class for styling-->
+      <xsl:when test="count(caption/p) = 2">
+        <!--the first -->
+        <xsl:for-each select="caption/p[position() = 1]">
+          <xsl:call-template name="preSiClass"/>
+        </xsl:for-each>
+        <!--doi-->
+        <p class="siDoi">
+          <xsl:value-of select="$siDOI"/>
+        </p>
+        <!--the last-->
+        <xsl:for-each select="caption/p[last()]">
+          <xsl:call-template name="postSiClass"/>
+        </xsl:for-each>
+      </xsl:when>
+
+      <!--if more than 2 caption/p elements, space out the verbal elements and close spacing between doi-->
+      <!--and file type and size information-->
+      <xsl:when test="count(caption/p) &gt; 2">
+        <xsl:apply-templates select="caption/p[position() &lt; last() - 1]"/>
+        <!--<xsl:apply-templates select="caption/p"/>-->
+
+        <!--second from last element gets a class for styling targetting-->
+        <!--<xsl:apply-templates select="caption/p[position() = last() - 1]"/>-->
+        <xsl:for-each select="caption/p[position() = last() - 1]">
+          <xsl:call-template name="preSiClass"/>
+        </xsl:for-each>
+
+        <!--doi goes here-->
+        <p class="siDoi">
+          <xsl:value-of select="$siDOI"/>
+        </p>
+
+        <!--final element-->
+        <xsl:for-each select="caption/p[last()]">
+          <xsl:call-template name="postSiClass"/>
+        </xsl:for-each>
+      </xsl:when>
+
+    </xsl:choose>
+
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="tex-math"/>
+
+  <!-- 1/4/12: Ambra modifications (remove mml prefix from all math elements, required for MathJax to work) -->
+  <xsl:template match="mml:*">
+    <xsl:element name="{local-name()}">
+      <xsl:copy-of copy-namespaces="no" select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="verse-group"/>
+  <xsl:template match="verse-line"/>
+
+  <!-- 1/4/12: suppress, we don't use. (removed aff/label, we process independently) -->
+  <xsl:template match="corresp/label | chem-struct/label | element-citation/label | mixed-citation/label"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="aff/label">
+    <strong>
+      <xsl:apply-templates/>
+    </strong>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use. (removed fn, fig, supplementary-material, disp-formula, table-wrap, we process independently) -->
+  <xsl:template match="app/label | boxed-text/label | chem-struct-wrap/label | ref/label | statement/label"
+                priority="2"/>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="author-notes/fn/label">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="disp-formula//label">
+    <span class="note">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications (all labels not otherwise specified) -->
+  <xsl:template match="label" name="label">
+    <xsl:apply-templates/>
+    <xsl:text>. </xsl:text>
+  </xsl:template>
+
+  <!-- ============================================================= -->
+  <!--  TABLES                                                       -->
+  <!-- ============================================================= -->
+
+  <!-- Tables are already in XHTML, and can simply be copied through -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="table | thead | tbody | col | colgroup | tr | th | td">
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="@*" mode="table-copy"/>
+      <xsl:call-template name="named-anchor"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="tfoot"/>
+  <xsl:template match="array/tbody"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="@*" mode="table-copy">
+    <xsl:copy-of copy-namespaces="no" select="."/>
+  </xsl:template>
+
+  <!-- ============================================================= -->
+  <!--  INLINE MISCELLANEOUS                                         -->
+  <!-- ============================================================= -->
+  <!--  Templates strictly for formatting follow; these are templates to handle various inline structures -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="abbrev"/>
+  <xsl:template match="abbrev/def"/>
+  <xsl:template match="p/address | license-p/address | named-content/p | styled-content/p"/>
+  <xsl:template match="address/*" mode="inline"/>
+  <xsl:template match="award-id"/>
+  <xsl:template match="award-id[normalize-space(@rid)]"/>
+  <xsl:template match="break"/>
+
+  <!-- 1/4/12: nlm contains email -->
+
+  <!-- 1/4/12: suppress, we don't use. removed ext-link from list (we process independently) -->
+  <xsl:template match="uri | inline-supplementary-material"/>
+
+  <!-- 10/28/13: suppress, we don't use -->
+  <xsl:template match="ext-link">
+    <xsl:variable name="previousText">
+      <xsl:value-of select="lower-case(normalize-space(preceding::text()[1]))"/>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="not(ancestor::ref-list) or not(substring($previousText, string-length($previousText)-3)='doi:')">
+        <a>
+          <xsl:call-template name="assign-href"/>
+          <xsl:apply-templates/>
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use  -->
+  <xsl:template match="funding-source"/>
+  <xsl:template match="hr"/>
+  <xsl:template match="chem-struct"/>
+
+  <!-- 1/4/12: nlm contains inline-formula (along with chem-struct, we only suppress chem-struct portion) -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="chem-struct-wrap/chem-struct"/>
+  <xsl:template match="milestone-start | milestone-end"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="object-id">
+    <xsl:choose>
+      <xsl:when test="@pub-id-type">
+        <xsl:value-of select="@pub-id-type"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <span class="gen">
+          <xsl:text>Object ID</xsl:text>
+        </span>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>:</xsl:text>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="sig"/>
+  <xsl:template match="target"/>
+  <xsl:template match="styled-content"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="named-content">
+    <xsl:choose>
+      <xsl:when test="@xlink:href">
+        <a>
+          <xsl:call-template name="assign-href"/>
+          <xsl:call-template name="assign-id"/>
+          <xsl:apply-templates/>
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <span>
+          <xsl:attribute name="class">
+            <xsl:value-of select="@content-type"/>
+          </xsl:attribute>
+          <xsl:call-template name="assign-id"/>
+          <xsl:apply-templates/>
+        </span>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="private-char"/>
+  <xsl:template match="glyph-data | glyph-ref"/>
+  <xsl:template match="related-article"/>
+  <xsl:template match="related-object"/>
+  <xsl:template match="xref[not(normalize-space())]" priority="-1"/>
+
+  <!-- 1/4/12: Ambra modifications (default if not one of the following ref-types (covers ref-type supplementary-material)) -->
+  <xsl:template match="xref">
+    <xsl:call-template name="assign-id"/>
+    <a href="#{@rid}">
+      <xsl:choose>
+        <!-- if xref not empty -->
+        <xsl:when test="child::node()">
+          <xsl:apply-templates/>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- if empty -->
+          <xsl:value-of select="@rid"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </a>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (superscript fn xrefs) -->
+  <xsl:template match="xref[@ref-type='fn']">
+    <span class="xref">
+      <xsl:call-template name="assign-id"/>
+      <sup>
+        <!-- if immediately-preceding sibling was an xref, punctuate (otherwise assume desired punctuation is in the source) -->
+        <xsl:if test="local-name(preceding-sibling::node()[1])='xref'">
+          <span class="gen">
+            <xsl:text>, </xsl:text>
+          </span>
+        </xsl:if>
+        <a href="#{@rid}">
+          <xsl:apply-templates/>
+        </a>
+      </sup>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12 Ambra-specific template (superscript table-fn xrefs) -->
+  <xsl:template match="xref[@ref-type='table-fn']">
+    <span class="xref">
+      <xsl:call-template name="assign-id"/>
+      <sup>
+        <!-- if immediately-preceding sibling was an xref, punctuate (otherwise assume desired punctuation is in the source) -->
+        <xsl:if test="local-name(preceding-sibling::node()[1])='xref'">
+          <span class="gen">
+            <xsl:text>, </xsl:text>
+          </span>
+        </xsl:if>
+        <xsl:apply-templates/>
+      </sup>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <xsl:template match="xref[@ref-type='bibr']">
+    <!-- if immediately-preceding sibling was an xref, punctuate (otherwise assume desired punctuation is in the source) -->
+    <xsl:if test="local-name(preceding-sibling::node()[1])='xref'">
+      <xsl:text>,</xsl:text>
+    </xsl:if>
+    <a href="#{@rid}">
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template -->
+  <!-- 6/13/12: added translate so names and ids of figs have dashes (for figure enhancement) -->
+  <xsl:template match="xref[@ref-type='fig'] | xref[@ref-type='table']">
+    <a href="#{translate(@rid, '.', '-')}">
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications (transform to <strong> instead of <b>) -->
+  <xsl:template match="bold">
+    <strong>
+      <xsl:apply-templates/>
+    </strong>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications (transform to <em> instead of <i>) -->
+  <xsl:template match="italic">
+    <em>
+      <xsl:apply-templates/>
+    </em>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="monospace">
+    <span class="monospace">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="overline">
+    <span class="overline">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="price"/>
+  <xsl:template match="roman"/>
+  <xsl:template match="sans-serif"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="sc">
+    <span class="small-caps">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="strike">
+    <span class="strike">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <!-- 1/4/12: nlm contains templates for sub and sup -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="underline">
+    <span class="underline">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+
+  <!-- ============================================================= -->
+  <!--  BACK MATTER                                                  -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: nlm contains variable loose-footnotes. we don't use -->
+
+  <!-- 1/4/12: Ambra modifications (creates back section) -->
+  <xsl:template name="make-back">
+    <xsl:for-each select="back">
+      <xsl:apply-templates select="ack"/>
+      <xsl:call-template name="author-contrib"/>
+      <xsl:apply-templates select="notes"/>
+      <xsl:apply-templates
+          select="*[not(self::title) and not(self::fn-group) and not(self::ack) and not(self::notes)]"/>
+      <xsl:call-template name="newline1"/>
+      <xsl:for-each select="//abstract[@abstract-type='patient']">
+        <div class="patient">
+          <a id="patient" name="patient" toc="patient" title="Patient Summary"/>
+          <h3>
+            <xsl:value-of select="title"/>
+          </h3>
+          <xsl:apply-templates select="*[not(self::title)]"/>
+        </div>
+      </xsl:for-each>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates author contributions section) -->
+  <xsl:template name="author-contrib">
+    <xsl:if test="../front/article-meta/author-notes/fn[@fn-type='con']">
+      <div class="contributions">
+        <a id="authcontrib" name="authcontrib" toc="authcontrib"
+           title="Author Contributions"/>
+        <h3>Author Contributions</h3>
+        <p>
+          <xsl:apply-templates select="../front/article-meta/author-notes/fn[@fn-type='con']"/>
+        </p>
+      </div>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="back"/>
+  <xsl:template name="footnotes"/>
+
+  <!-- 1/4/12: Ambra modifications (creates acknowledgments section) -->
+  <xsl:template match="ack">
+    <xsl:call-template name="newline1"/>
+    <xsl:if test="position()>1">
+      <hr class="section-rule"/>
+    </xsl:if>
+    <xsl:call-template name="newline1"/>
+    <div>
+      <xsl:call-template name="assign-id"/>
+      <xsl:if test="not(title)">
+        <a id="ack" name="ack" toc="ack" title="Acknowledgments"/>
+        <h3>Acknowledgments</h3>
+        <xsl:call-template name="newline1"/>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="app-group"/>
+  <xsl:template match="back/bio"/>
+  <xsl:template match="back/fn-group"/>
+  <xsl:template match="back/glossary"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="back/ref-list">
+    <xsl:call-template name="ref-list"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="back/notes">
+    <xsl:call-template name="newline1"/>
+    <xsl:if test="position()>1">
+      <hr class="section-rule"/>
+    </xsl:if>
+    <xsl:call-template name="newline1"/>
+    <div class="notes">
+      <xsl:call-template name="assign-id"/>
+      <xsl:apply-templates/>
+      <xsl:call-template name="newline1"/>
+    </div>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="backmatter-section"/>
+
+
+  <!-- ============================================================= -->
+  <!--  FOOTNOTES                                                    -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="fn">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="fn-group/fn | table-wrap-foot/fn | table-wrap-foot/fn-group/fn"/>
+  <xsl:template match="fn" mode="footnote"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="fn/p">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- ============================================================= -->
+  <!--  MODE 'label-text'
+      Generates label text for elements and their cross-references -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: nlm contains a bunch of variables, we don't use -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template mode="label" match="*" name="block-label"/>
+  <xsl:template mode="label" match="ref"/>
+  <xsl:template match="app" mode="label-text"/>
+  <xsl:template match="boxed-text" mode="label-text"/>
+  <xsl:template match="disp-formula" mode="label-text"/>
+  <xsl:template match="chem-struct-wrap" mode="label-text"/>
+  <xsl:template match="fig" mode="label-text"/>
+  <xsl:template match="front//fn" mode="label-text"/>
+  <xsl:template match="table-wrap//fn" mode="label-text"/>
+  <xsl:template match="fn" mode="label-text"/>
+  <xsl:template match="ref" mode="label-text"/>
+  <xsl:template match="statement" mode="label-text"/>
+  <xsl:template match="supplementary-material" mode="label-text"/>
+  <xsl:template match="table-wrap" mode="label-text"/>
+  <xsl:template match="*" mode="label-text"/>
+  <xsl:template match="label" mode="label-text"/>
+  <xsl:template match="text()" mode="inline-label-text"/>
+
+  <!-- ============================================================= -->
+  <!--  Writing a name                                               -->
+  <!-- ============================================================= -->
+
+  <!-- Called when displaying structured names in metadata         -->
+
+  <!-- 1/4/12: Ambra modifications (creates author names in metadata) -->
+  <!-- 1/4/12: commented out logic for eastern/western names. edit when we implement name-style eastern -->
+  <xsl:template name="write-name" match="name">
+    <xsl:apply-templates select="prefix" mode="inline-name"/>
+    <!-- <xsl:apply-templates select="surname[../@name-style='eastern']" mode="inline-name"/> -->
+    <xsl:apply-templates select="given-names" mode="contrib-abbr"/>
+    <xsl:apply-templates select="surname" mode="inline-name"/>
+    <!--<xsl:apply-templates select="surname[not(../@name-style='eastern')]" mode="inline-name"/> -->
+    <xsl:apply-templates select="suffix" mode="inline-name"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="prefix" mode="inline-name">
+    <xsl:apply-templates/>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <!-- 1/4/12: commented out eastern/western logic. edit when we implement name-style eastern (possibly use generic nlm) -->
+  <xsl:template match="given-names" mode="inline-name">
+    <xsl:apply-templates/>
+    <xsl:text> </xsl:text>
+    <!--<xsl:if test="../surname[not(../@name-style='eastern')] | ../suffix">
+      <xsl:text> </xsl:text>
+    </xsl:if>-->
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications (overrides both nlm contrib/name/surname mode inline-name and surname mode inline-name (identical in nlm)) -->
+  <!-- 1/4/12: edit when we implement name-style eastern, maybe use nlm version -->
+  <xsl:template match="surname" mode="inline-name">
+    <xsl:apply-templates/>
+    <!--<xsl:if test="../given-names[../@name-style='eastern'] | ../suffix">
+      <xsl:text> </xsl:text>
+    </xsl:if>-->
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template match="suffix" mode="inline-name">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="string-name"/>
+
+  <!-- ============================================================= -->
+  <!--  UTILITY TEMPLATES                                           -->
+  <!-- ============================================================= -->
+
+  <xsl:template name="makeIdNameFromXpathLocation">
+    <xsl:variable name="idFromXpath">
+      <xsl:call-template name="createIdNameXpath">
+        <xsl:with-param name="theNode" select="."/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:attribute name="id">
+      <xsl:value-of select="substring($idFromXpath, 2)"/>
+    </xsl:attribute>
+    <xsl:attribute name="name">
+      <xsl:value-of select="substring($idFromXpath, 2)"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template name="createIdNameXpath">
+    <xsl:param name="theNode" select="."/>
+    <xsl:choose>
+      <xsl:when test="$theNode[1]">
+        <xsl:choose>
+          <xsl:when test="not($theNode[1]/..)">
+            <!-- cann't figure out when this is used -->
+            <xsl:text>.</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:for-each select="$theNode[1]/ancestor-or-self::*[not(self::aml:annotated)]">
+              <xsl:text/>.<xsl:value-of select="name()"/>
+              <xsl:text/><xsl:value-of select="count(preceding-sibling::*[name() = name(current())]) + 1"/><xsl:text/>
+            </xsl:for-each>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="$theNode">
+        <xsl:choose>
+          <xsl:when test="not($theNode/..)">
+            <!-- cann't figure out when this is used -->
+            <xsl:text>.</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:for-each select="$theNode/ancestor-or-self::*[not(self::aml:annotated)]">
+              <xsl:text/>.<xsl:value-of select="name()"/>
+              <xsl:text/><xsl:value-of select="count(preceding-sibling::*[name() = name(current())]) + 1"/><xsl:text/>
+            </xsl:for-each>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (prevents double punctuation if xml contains valid punctuation already) -->
+  <xsl:template name="punctuation">
+    <xsl:if
+        test="not(ends-with(normalize-space(),'.')) and not(ends-with(normalize-space(),'?')) and not(ends-with(normalize-space(),'!'))">
+      <xsl:text>.</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (works with next two linebreak templates) -->
+  <xsl:template match="text()">
+    <!-- do some character transformations first-->
+    <xsl:variable name="str" select="translate(., '&#8194;&#x200A;&#8764;&#x02236;&#x02208;', '  ~:&#x404;') "/>
+    <xsl:choose>
+      <!-- no need to progress further if the entire element is less then 40 characters -->
+      <xsl:when test="string-length($str) &gt; 40">
+        <xsl:call-template name="linebreaklongwords">
+          <xsl:with-param name="str" select="$str"/>
+          <xsl:with-param name="len" select="40"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$str"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (works with following template to break long strings) -->
+  <!-- break words longer then len characters -->
+  <xsl:template name="linebreaklongwords">
+    <xsl:param name="str"/>
+    <xsl:param name="len"/>
+    <xsl:for-each select="tokenize($str,'\s')">
+      <xsl:choose>
+        <xsl:when test="string-length(.) &gt; $len">
+          <xsl:call-template name="linebreaklongwordsub">
+            <xsl:with-param name="str" select="."/>
+            <xsl:with-param name="len" select="$len"/>
+            <!-- zero length space -->
+            <xsl:with-param name="char">
+              <xsl:text>&#8203;</xsl:text>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:choose>
+            <xsl:when test="position()=last()">
+              <xsl:copy-of select="."/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:copy-of select="."/>
+              <xsl:text> </xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (works with above template to break long strings) -->
+  <xsl:template name="linebreaklongwordsub">
+    <xsl:param name="str"/>
+    <xsl:param name="len"/>
+    <xsl:param name="char"/>
+    <xsl:choose>
+      <xsl:when test="string-length($str) &gt; $len">
+        <xsl:value-of select="substring($str,1,$len)"/>
+        <xsl:value-of select="$char"/>
+        <xsl:call-template name="linebreaklongwordsub">
+          <xsl:with-param name="str" select="substring($str,$len + 1)"/>
+          <xsl:with-param name="len" select="$len"/>
+          <xsl:with-param name="char" select="$char"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$str"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (used for displaying annotations) -->
+  <xsl:template name="createAnnotationSpan">
+    <xsl:variable name="regionId" select="@aml:id"/>
+    <xsl:variable name="regionNumComments"
+                  select="number(/article/aml:regions/aml:region[@aml:id=$regionId]/@aml:numComments)"/>
+    <xsl:variable name="regionNumMinorCorrections"
+                  select="number(/article/aml:regions/aml:region[@aml:id=$regionId]/@aml:numMinorCorrections)"/>
+    <xsl:variable name="regionNumFormalCorrections"
+                  select="number(/article/aml:regions/aml:region[@aml:id=$regionId]/@aml:numFormalCorrections)"/>
+    <xsl:variable name="regionNumRetractions"
+                  select="number(/article/aml:regions/aml:region[@aml:id=$regionId]/@aml:numRetractions)"/>
+    <xsl:element name="span">
+      <!-- convey the number of comments, minor/formal corrections, and retractions -->
+      <xsl:attribute name="num_c">
+        <xsl:value-of select="$regionNumComments"/>
+      </xsl:attribute>
+      <xsl:attribute name="num_mc">
+        <xsl:value-of select="$regionNumMinorCorrections"/>
+      </xsl:attribute>
+      <xsl:attribute name="num_fc">
+        <xsl:value-of select="$regionNumFormalCorrections"/>
+      </xsl:attribute>
+      <xsl:attribute name="num_retractions">
+        <xsl:value-of select="$regionNumRetractions"/>
+      </xsl:attribute>
+      <!-- populate the span tag's class attribute based on the presence of comments vs. corrections -->
+      <xsl:attribute name="class">
+        <!-- this is always considered a note -->
+        <xsl:text>note public</xsl:text>
+        <xsl:if test="$regionNumMinorCorrections &gt; 0">
+          <xsl:text> minrcrctn</xsl:text>
+        </xsl:if>
+        <xsl:if test="$regionNumFormalCorrections &gt; 0">
+          <xsl:text> frmlcrctn</xsl:text>
+        </xsl:if>
+        <xsl:if test="$regionNumRetractions &gt; 0">
+          <xsl:text> retractionCssStyle</xsl:text>
+        </xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="title">User Annotation</xsl:attribute>
+      <xsl:attribute name="annotationId">
+        <xsl:for-each select="/article/aml:regions/aml:region[@aml:id=$regionId]/aml:annotation">
+          <xsl:value-of select="@aml:id"/>
+          <xsl:if test="(following-sibling::aml:annotation)">
+            <xsl:text>,</xsl:text>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:attribute>
+      <!-- only add an annotation to the display list if this is the beginning of the annotation -->
+      <xsl:variable name="displayAnn">
+        <xsl:variable name="annId" select="@aml:id"/>
+        <xsl:if test="@aml:first">
+          <xsl:for-each select="/article/aml:regions/aml:region[@aml:id=$regionId]/aml:annotation">
+            <xsl:variable name="localAnnId" select="@aml:id"/>
+            <xsl:if test="count(../preceding-sibling::aml:region/aml:annotation[@aml:id=$localAnnId]) = 0">
+              <xsl:text>,</xsl:text>
+              <xsl:value-of select="@aml:id"/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:if>
+      </xsl:variable>
+      <xsl:if test="not($displayAnn='')">
+        <xsl:element name="a">
+          <xsl:attribute name="href">#</xsl:attribute>
+          <xsl:attribute name="class">bug public</xsl:attribute>
+          <xsl:attribute name="id">
+            <xsl:value-of select="concat('annAnchor',@aml:id)"/>
+          </xsl:attribute>
+          <xsl:attribute name="displayId">
+            <!-- get rid of first comma in list -->
+            <xsl:value-of select="substring($displayAnn,2)"/>
+          </xsl:attribute>
+          <xsl:attribute name="onclick">return(ambra.displayComment.show(this));</xsl:attribute>
+          <xsl:attribute name="onmouseover">ambra.displayComment.mouseoverComment(this);</xsl:attribute>
+          <xsl:attribute name="onmouseout">ambra.displayComment.mouseoutComment(this);</xsl:attribute>
+          <xsl:attribute name="title">Click to preview this note</xsl:attribute>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (used for displaying annotations (xml is coming from ambra, not article xml)) -->
+  <xsl:template match="aml:annotated">
+    <xsl:call-template name="createAnnotationSpan"/>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates newlines for legibility of source html) -->
+  <xsl:template name="newline1">
+    <xsl:text>&#xA;</xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: Ambra-specific template (creates newlines for legibility of source html) -->
+  <xsl:template name="newline2">
+    <xsl:text>&#xA;</xsl:text>
+    <xsl:text>&#xA;</xsl:text>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="append-pub-type"/>
+  <xsl:template name="metadata-labeled-entry"/>
+  <xsl:template name="metadata-entry"/>
+  <xsl:template name="metadata-area"/>
+  <xsl:template name="make-label-text"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template name="assign-id">
+    <xsl:if test="@id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="assign-src"/>
+
+  <!-- 1/4/12: Ambra modifications -->
+  <xsl:template name="assign-href">
+    <xsl:if test="@xlink:href">
+      <xsl:attribute name="href">
+        <xsl:value-of select="@xlink:href"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="named-anchor"/>
+
+  <!-- ============================================================= -->
+  <!--  Process warnings                                             -->
+  <!-- ============================================================= -->
+  <!-- Generates a list of warnings to be reported due to processing anomalies. -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="process-warnings"/>
+
+  <!-- ============================================================= -->
+  <!--  id mode                                                      -->
+  <!-- ============================================================= -->
+  <!-- An id can be derived for any element. If an @id is given, it is presumed unique and copied. If not, one is generated.   -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template match="*" mode="id"/>
+  <xsl:template match="article | sub-article | response" mode="id"/>
+
+  <!-- ============================================================= -->
+  <!--  "format-date"                                                -->
+  <!-- ============================================================= -->
+  <!-- Maps a structured date element to a string -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="format-date"/>
+  <xsl:template match="day | season | year" mode="map"/>
+
+  <!-- 1/4/12: nlm contains month mode map -->
+
+  <!-- ============================================================= -->
+  <!--  "author-string" writes authors' names in sequence            -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="author-string"/>
+
+  <!-- ============================================================= -->
+  <!--  Footer branding                                              -->
+  <!-- ============================================================= -->
+
+  <!-- 1/4/12: suppress, we don't use -->
+  <xsl:template name="footer-branding"/>
+
+
+</xsl:stylesheet>

--- a/src/main/webapp/WEB-INF/themes/root/xform/jpub3-html.xsl
+++ b/src/main/webapp/WEB-INF/themes/root/xform/jpub3-html.xsl
@@ -43,10 +43,10 @@
 <!-- ============================================================= -->
 
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                exclude-result-prefixes="xlink mml">
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  exclude-result-prefixes="xlink mml">
 
 
   <!--<xsl:output method="xml" indent="no" encoding="UTF-8"
@@ -55,14 +55,14 @@
 
 
   <xsl:output doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN"
-              doctype-system="http://www.w3.org/TR/html4/loose.dtd"
-              encoding="UTF-8"/>
-
+    doctype-system="http://www.w3.org/TR/html4/loose.dtd"
+    encoding="UTF-8"/>
+ 
   <xsl:strip-space elements="*"/>
 
   <!-- Space is preserved in all elements allowing #PCDATA -->
   <xsl:preserve-space
-      elements="abbrev abbrev-journal-title access-date addr-line aff
+    elements="abbrev abbrev-journal-title access-date addr-line aff 
               alt-text alt-title article-id article-title attrib 
               award-id bold chapter-title chem-struct collab comment 
               compound-kwd-part conf-acronym conf-date conf-loc conf-name 
@@ -105,7 +105,7 @@
 
   <!-- Enabling retrieval of cross-references to objects -->
   <xsl:key name="xref-by-rid" match="xref" use="@rid"/>
-
+  
   <!-- ============================================================= -->
   <!--  ROOT TEMPLATE - HANDLES HTML FRAMEWORK                       -->
   <!-- ============================================================= -->
@@ -128,9 +128,9 @@
           <xsl:call-template name="author-string"/>
         </xsl:variable>
         <xsl:value-of select="normalize-space($authors)"/>
-        <xsl:if test="normalize-space($authors)">:</xsl:if>
+        <xsl:if test="normalize-space($authors)">: </xsl:if>
         <xsl:value-of
-            select="/article/front/article-meta/title-group/article-title[1]"/>
+          select="/article/front/article-meta/title-group/article-title[1]"/>
       </title>
       <link rel="stylesheet" type="text/css" href="{$css}"/>
       <!-- XXX check: any other header stuff? XXX -->
@@ -138,9 +138,9 @@
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  TOP LEVEL                                                    -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  TOP LEVEL                                                    -->
+<!-- ============================================================= -->
 
   <!--
       content model for article:
@@ -152,7 +152,7 @@
       
       content model for response:
          ((front|front-stub),body?,back?,floats-group?) -->
-
+  
   <xsl:template match="article">
     <xsl:call-template name="make-article"/>
   </xsl:template>
@@ -163,9 +163,9 @@
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  "make-article" for the document architecture                 -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  "make-article" for the document architecture                 -->
+<!-- ============================================================= -->
 
   <xsl:template name="make-article">
     <!-- Generates a series of (flattened) divs for contents of any
@@ -307,7 +307,7 @@
             <div class="metadata-group">
 
               <xsl:apply-templates mode="metadata"
-                                   select="email | ext-link | uri | self-uri"/>
+                select="email | ext-link | uri | self-uri"/>
 
               <xsl:apply-templates mode="metadata" select="product"/>
 
@@ -335,7 +335,7 @@
               <xsl:apply-templates mode="metadata" select="isbn"/>
 
               <xsl:apply-templates mode="metadata"
-                                   select="supplement | related-article | conference"/>
+                select="supplement | related-article | conference"/>
 
               <xsl:apply-templates mode="metadata" select="article-id"/>
 
@@ -369,7 +369,7 @@
             <td>
               <div class="metadata-group">
                 <xsl:apply-templates mode="metadata"
-                                     select="aff | author-notes"/>
+                  select="aff | author-notes"/>
               </div>
             </td>
           </tr>
@@ -390,7 +390,7 @@
                   <xsl:apply-templates select="title/node()"/>
                   <xsl:if test="not(normalize-space(title))">
                     <span class="generated">
-                      <xsl:if test="self::trans-abstract">Translated</xsl:if>
+                      <xsl:if test="self::trans-abstract">Translated </xsl:if>
                       <xsl:text>Abstract</xsl:text>
                     </span>
                   </xsl:if>
@@ -424,7 +424,7 @@
     </table>
     <!-- end of big front-matter pull -->
   </xsl:template>
-
+  
   <xsl:template name="footer-metadata">
     <!-- handles: article-categories, kwd-group, counts, 
            supplementary-material, custom-meta-group
@@ -433,29 +433,29 @@
     <xsl:for-each select="front/article-meta | front-stub">
       <xsl:if test="article-categories | kwd-group | counts |
                     supplementary-material | custom-meta-group">
-        <table width="100%" class="metadata">
-          <tr>
-            <td>
-              <hr class="part-rule"/>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <h4 class="generated">
-                <xsl:text>Article Information (continued)</xsl:text>
-              </h4>
-              <div class="metadata-group">
-                <xsl:apply-templates mode="metadata"
-                                     select="supplementary-material"/>
+      <table width="100%" class="metadata">
+        <tr>
+          <td>
+            <hr class="part-rule"/>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <h4 class="generated">
+              <xsl:text>Article Information (continued)</xsl:text>
+            </h4>
+            <div class="metadata-group">
+              <xsl:apply-templates mode="metadata"
+                select="supplementary-material"/>
 
-                <xsl:apply-templates mode="metadata"
-                                     select="article-categories | kwd-group | counts"/>
+              <xsl:apply-templates mode="metadata"
+                select="article-categories | kwd-group | counts"/>
 
-                <xsl:apply-templates mode="metadata" select="custom-meta-group"/>
-              </div>
-            </td>
-          </tr>
-        </table>
+              <xsl:apply-templates mode="metadata" select="custom-meta-group"/>
+            </div>
+          </td>
+        </tr>
+      </table>
       </xsl:if>
     </xsl:for-each>
 
@@ -486,13 +486,13 @@
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  METADATA PROCESSING                                          -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  METADATA PROCESSING                                          -->
+<!-- ============================================================= -->
 
-  <!--  Includes mode "metadata" for front matter, along with
-        "metadata-inline" for metadata elements collapsed into
-        inline sequences, plus associated named templates            -->
+<!--  Includes mode "metadata" for front matter, along with 
+      "metadata-inline" for metadata elements collapsed into 
+      inline sequences, plus associated named templates            -->
 
   <!-- journal-meta content:
        journal-id+, journal-title-group*, issn+, isbn*, publisher?,
@@ -555,7 +555,7 @@
 
 
   <xsl:template match="publisher-loc" mode="metadata-inline">
-    <span class="generated">(</span>
+    <span class="generated"> (</span>
     <xsl:apply-templates/>
     <span class="generated">)</span>
   </xsl:template>
@@ -736,7 +736,7 @@
         <xsl:with-param name="contents">
           <xsl:for-each select="copyright-year | copyright-holder">
             <xsl:apply-templates/>
-            <xsl:if test="not(position()=last())">,</xsl:if>
+            <xsl:if test="not(position()=last())">, </xsl:if>
           </xsl:for-each>
         </xsl:with-param>
       </xsl:call-template>
@@ -761,7 +761,7 @@
           <span class="data">
             <xsl:value-of select="@license-type"/>
             <xsl:if test="@xlink:href">
-              <xsl:if test="@license-type">,</xsl:if>
+              <xsl:if test="@license-type">, </xsl:if>
               <a>
                 <xsl:call-template name="assign-href"/>
                 <xsl:value-of select="@xlink:href"/>
@@ -781,10 +781,10 @@
         <xsl:text>Date</xsl:text>
         <xsl:for-each select="@date-type">
           <xsl:choose>
-            <xsl:when test=".='accepted'">accepted</xsl:when>
-            <xsl:when test=".='received'">received</xsl:when>
-            <xsl:when test=".='rev-request'">revision requested</xsl:when>
-            <xsl:when test=".='rev-recd'">revision received</xsl:when>
+            <xsl:when test=".='accepted'"> accepted</xsl:when>
+            <xsl:when test=".='received'"> received</xsl:when>
+            <xsl:when test=".='rev-request'"> revision requested</xsl:when>
+            <xsl:when test=".='rev-recd'"> revision received</xsl:when>
           </xsl:choose>
         </xsl:for-each>
       </xsl:with-param>
@@ -818,14 +818,14 @@
             <xsl:with-param name="label">Volume</xsl:with-param>
             <xsl:with-param name="contents">
               <xsl:apply-templates select="volume | volume-series"
-                                   mode="metadata-inline"/>
+                mode="metadata-inline"/>
               <xsl:apply-templates select="volume-id" mode="metadata-inline"/>
             </xsl:with-param>
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates select="volume | volume-id | volume-series"
-                               mode="metadata"/>
+            mode="metadata"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:if>
@@ -895,17 +895,17 @@
   <xsl:template name="issue-info">
     <!-- handles issue?, issue-id*, issue-title*, issue-sponsor*, issue-part?, supplement? -->
     <xsl:variable name="issue-info"
-                  select="issue | issue-id | issue-title |
+      select="issue | issue-id | issue-title |
       issue-sponsor | issue-part"/>
     <xsl:choose>
       <xsl:when
-          test="$issue-info and not(issue-id[2] | issue-title[2] | issue-sponsor | issue-part)">
+        test="$issue-info and not(issue-id[2] | issue-title[2] | issue-sponsor | issue-part)">
         <!-- if there are only one issue, issue-id and issue-title and nothing else, we make one line only -->
         <xsl:call-template name="metadata-labeled-entry">
           <xsl:with-param name="label">Issue</xsl:with-param>
           <xsl:with-param name="contents">
             <xsl:apply-templates select="issue | issue-title"
-                                 mode="metadata-inline"/>
+              mode="metadata-inline"/>
             <xsl:apply-templates select="issue-id" mode="metadata-inline"/>
           </xsl:with-param>
         </xsl:call-template>
@@ -977,7 +977,7 @@
         <xsl:with-param name="label">
           <xsl:text>Page</xsl:text>
           <xsl:if
-              test="normalize-space(lpage[not(.=../fpage)])
+            test="normalize-space(lpage[not(.=../fpage)])
                    or normalize-space(page-range)">
             <!-- we have multiple pages if lpage exists and is not equal fpage,
                or if we have a page-range -->
@@ -1004,8 +1004,7 @@
   <xsl:template match="elocation-id" mode="metadata">
     <xsl:call-template name="metadata-labeled-entry">
       <xsl:with-param name="label">Electronic Location
-        Identifier
-      </xsl:with-param>
+      Identifier</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 
@@ -1023,10 +1022,10 @@
     <xsl:call-template name="metadata-labeled-entry">
       <xsl:with-param name="label">
         <xsl:text>Related </xsl:text>
-        <xsl:choose>
-          <xsl:when test="self::related-object">object</xsl:when>
-          <xsl:otherwise>article</xsl:otherwise>
-        </xsl:choose>
+          <xsl:choose>
+            <xsl:when test="self::related-object">object</xsl:when>
+            <xsl:otherwise>article</xsl:otherwise>
+          </xsl:choose>
         <xsl:for-each select="@related-article-type | @object-type">
           <xsl:text> (</xsl:text>
           <span class="data">
@@ -1059,7 +1058,7 @@
        conf-num?, conf-loc?, conf-sponsor*, conf-theme?) -->
     <xsl:choose>
       <xsl:when
-          test="not(conf-name[2] | conf-acronym[2] | conf-sponsor |
+        test="not(conf-name[2] | conf-acronym[2] | conf-sponsor |
                   conf-theme)">
         <!-- if there is no second name or acronym, and no sponsor
              or theme, we make one line only -->
@@ -1067,12 +1066,12 @@
           <xsl:with-param name="label">Conference</xsl:with-param>
           <xsl:with-param name="contents">
             <xsl:apply-templates select="conf-acronym | conf-name"
-                                 mode="metadata-inline"/>
+              mode="metadata-inline"/>
             <xsl:apply-templates select="conf-num" mode="metadata-inline"/>
             <xsl:if test="conf-date | conf-loc">
-              <span class="generated">(</span>
+              <span class="generated"> (</span>
               <xsl:for-each select="conf-date | conf-loc">
-                <xsl:if test="position() = 2">,</xsl:if>
+                <xsl:if test="position() = 2">, </xsl:if>
                 <xsl:apply-templates select="." mode="metadata-inline"/>
               </xsl:for-each>
               <span class="generated">)</span>
@@ -1139,10 +1138,10 @@
   <xsl:template match="conf-name | conf-acronym" mode="metadata-inline">
     <!-- we only hit this template if there is at most one of each -->
     <xsl:variable name="following"
-                  select="preceding-sibling::conf-name | preceding-sibling::conf-acronym"/>
+      select="preceding-sibling::conf-name | preceding-sibling::conf-acronym"/>
     <!-- if we come after the other, we go in parentheses -->
     <xsl:if test="$following">
-      <span class="generated">(</span>
+      <span class="generated"> (</span>
     </xsl:if>
     <xsl:apply-templates/>
     <xsl:if test="$following">
@@ -1244,7 +1243,7 @@
     <!-- content model:
     article-title, subtitle*, trans-title-group*, alt-title*, fn-group? -->
     <xsl:apply-templates select="article-title | subtitle | trans-title-group"
-                         mode="metadata"/>
+      mode="metadata"/>
     <xsl:if test="alt-title | fn-group">
       <div class="document-title-notes metadata-group">
         <xsl:apply-templates select="alt-title | fn-group" mode="metadata"/>
@@ -1262,7 +1261,7 @@
 
 
   <xsl:template match="title-group/subtitle | trans-title-group/subtitle"
-                mode="metadata">
+    mode="metadata">
     <h2 class="document-title">
       <xsl:apply-templates/>
     </h2>
@@ -1313,46 +1312,46 @@
 
 
   <xsl:template mode="metadata" match="contrib-group">
-    <!-- content model of contrib-group:
-      (contrib+,
-      (address | aff | author-comment | bio | email |
-      ext-link | on-behalf-of | role | uri | xref)*) -->
-    <!-- each contrib makes a row: name at left, details at right -->
-    <xsl:for-each select="contrib">
-      <!-- content model of contrib:
-        ((anonymous | collab | name)*, (degrees)*,
-         (address | aff | author-comment | bio | email |
-          ext-link | on-behalf-of | role | uri | xref)*) -->
-      <tr>
-        <td align="right">
-          <xsl:call-template name="contrib-identify">
-            <!-- handles
-                 (anonymous | collab | name | degrees | xref) -->
-          </xsl:call-template>
-        </td>
-        <td>
-          <xsl:call-template name="contrib-info">
-            <!-- handles
-                 (address | aff | author-comment | bio | email |
-                  ext-link | on-behalf-of | role | uri) -->
-          </xsl:call-template>
-        </td>
-      </tr>
-    </xsl:for-each>
-    <!-- end of contrib -->
-    <xsl:variable name="misc-contrib-data"
-                  select="*[not(self::contrib | self::xref)]"/>
-    <xsl:if test="$misc-contrib-data">
-      <tr>
-        <td>&#160;</td>
-        <td>
-          <div class="metadata-group">
-            <xsl:apply-templates mode="metadata"
-                                 select="$misc-contrib-data"/>
-          </div>
-        </td>
-      </tr>
-    </xsl:if>
+      <!-- content model of contrib-group:
+        (contrib+, 
+        (address | aff | author-comment | bio | email |
+        ext-link | on-behalf-of | role | uri | xref)*) -->
+      <!-- each contrib makes a row: name at left, details at right -->
+      <xsl:for-each select="contrib">
+        <!-- content model of contrib: 
+          ((anonymous | collab | name)*, (degrees)*, 
+           (address | aff | author-comment | bio | email |
+            ext-link | on-behalf-of | role | uri | xref)*) -->
+        <tr>
+          <td align="right">
+            <xsl:call-template name="contrib-identify">
+              <!-- handles
+                   (anonymous | collab | name | degrees | xref) -->
+            </xsl:call-template>
+          </td>
+          <td>
+            <xsl:call-template name="contrib-info">
+              <!-- handles
+                   (address | aff | author-comment | bio | email |
+                    ext-link | on-behalf-of | role | uri) -->
+            </xsl:call-template>
+          </td>
+        </tr>
+      </xsl:for-each>
+      <!-- end of contrib -->
+      <xsl:variable name="misc-contrib-data"
+        select="*[not(self::contrib | self::xref)]"/>
+      <xsl:if test="$misc-contrib-data">
+        <tr>
+          <td>&#160;</td>
+          <td>
+            <div class="metadata-group">
+              <xsl:apply-templates mode="metadata"
+                select="$misc-contrib-data"/>
+            </div>
+          </td>
+        </tr>
+      </xsl:if>
   </xsl:template>
 
 
@@ -1360,7 +1359,7 @@
     <!-- Placed in a left-hand pane  -->
     <div class="metadata-group">
       <xsl:apply-templates mode="metadata"
-                           select="anonymous | collab | name"/>
+        select="anonymous | collab | name"/>
       <!-- degrees | xref will be handled along with the last
            of these children by the contrib-amend template -->
     </div>
@@ -1371,7 +1370,7 @@
     <xsl:call-template name="metadata-entry">
       <xsl:with-param name="contents">
         <xsl:for-each
-            select="self::*[not(preceding-sibling::*)]/parent::contrib">
+          select="self::*[not(preceding-sibling::*)]/parent::contrib">
           <!-- mark with an anchor for the parent contrib if this
                element is first -->
           <xsl:call-template name="named-anchor"/>
@@ -1379,9 +1378,9 @@
         <xsl:text>Anonymous</xsl:text>
         <xsl:call-template name="contrib-amend">
           <xsl:with-param name="last-contrib"
-                          select="not(../following-sibling::contrib)"/>
-          <!-- passes Boolean false if we are inside the last
-               contrib -->
+            select="not(../following-sibling::contrib)"/>
+            <!-- passes Boolean false if we are inside the last
+                 contrib -->
         </xsl:call-template>
       </xsl:with-param>
     </xsl:call-template>
@@ -1392,25 +1391,25 @@
     <xsl:call-template name="metadata-entry">
       <xsl:with-param name="contents">
         <xsl:for-each
-            select="self::*[not(preceding-sibling::*)]/parent::contrib">
+          select="self::*[not(preceding-sibling::*)]/parent::contrib">
           <!-- mark with an anchor for the parent contrib if this
                element is first -->
           <xsl:call-template name="named-anchor"/>
         </xsl:for-each>
         <xsl:choose>
-          <xsl:when test="contrib-group">
-            <xsl:apply-templates select="text()"/>
-            <xsl:apply-templates select="contrib-group" mode="metadata"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:apply-templates/>
-          </xsl:otherwise>
+        	<xsl:when test="contrib-group">
+        		<xsl:apply-templates select="text()"/>
+        		<xsl:apply-templates select="contrib-group" mode="metadata"/>
+        	</xsl:when>
+        	<xsl:otherwise>
+        		<xsl:apply-templates/>
+        	</xsl:otherwise>
         </xsl:choose>
         <xsl:call-template name="contrib-amend">
           <xsl:with-param name="last-contrib"
-                          select="not(../following-sibling::contrib)"/>
-          <!-- passes Boolean false if we are inside the last
-               contrib -->
+            select="not(../following-sibling::contrib)"/>
+            <!-- passes Boolean false if we are inside the last
+                 contrib -->
         </xsl:call-template>
       </xsl:with-param>
     </xsl:call-template>
@@ -1421,7 +1420,7 @@
     <xsl:call-template name="metadata-entry">
       <xsl:with-param name="contents">
         <xsl:for-each
-            select="self::*[not(preceding-sibling::*)]/parent::contrib">
+          select="self::*[not(preceding-sibling::*)]/parent::contrib">
           <!-- mark with an anchor for the parent contrib if this 
                element is first -->
           <xsl:call-template name="named-anchor"/>
@@ -1430,9 +1429,9 @@
         <xsl:call-template name="write-name"/>
         <xsl:call-template name="contrib-amend">
           <xsl:with-param name="last-contrib"
-                          select="not(../following-sibling::contrib)"/>
-          <!-- passes Boolean false if we are inside the last
-               contrib -->
+            select="not(../following-sibling::contrib)"/>
+            <!-- passes Boolean false if we are inside the last
+                 contrib -->
         </xsl:call-template>
       </xsl:with-param>
     </xsl:call-template>
@@ -1449,10 +1448,10 @@
                       following-sibling::collab |
                       following-sibling::name)">
       <xsl:apply-templates mode="metadata-inline"
-                           select="../degrees | ../xref"/>
+        select="../degrees | ../xref"/>
       <xsl:if test="$last-contrib">
         <xsl:apply-templates mode="metadata-inline"
-                             select="parent::contrib/following-sibling::xref"/>
+          select="parent::contrib/following-sibling::xref"/>
       </xsl:if>
     </xsl:if>
   </xsl:template>
@@ -1473,21 +1472,21 @@
     <!-- Placed in a right-hand pane -->
     <div class="metadata-group">
       <xsl:apply-templates mode="metadata"
-                           select="address | aff | author-comment | bio | email |
+        select="address | aff | author-comment | bio | email |
                 ext-link | on-behalf-of | role | uri"/>
     </div>
   </xsl:template>
 
 
   <xsl:template mode="metadata"
-                match="address[not(addr-line) or not(*[2])]">
+    match="address[not(addr-line) or not(*[2])]">
     <!-- when we have no addr-line or a single child, we generate
          a single unlabelled line -->
-    <xsl:call-template name="metadata-entry">
-      <xsl:with-param name="contents">
-        <xsl:call-template name="address-line"/>
-      </xsl:with-param>
-    </xsl:call-template>
+        <xsl:call-template name="metadata-entry">
+          <xsl:with-param name="contents">
+            <xsl:call-template name="address-line"/>
+          </xsl:with-param>
+        </xsl:call-template>
   </xsl:template>
 
 
@@ -1694,7 +1693,7 @@
 
 
   <xsl:template mode="metadata"
-                match="fig-count | table-count | equation-count |
+    match="fig-count | table-count | equation-count |
            ref-count | page-count | word-count">
     <xsl:call-template name="metadata-labeled-entry">
       <xsl:with-param name="label">
@@ -1708,37 +1707,31 @@
 
 
   <xsl:template match="table-count"
-                mode="metadata-label">Figures
-  </xsl:template>
+    mode="metadata-label">Figures</xsl:template>
 
 
   <xsl:template match="table-count"
-                mode="metadata-label">Tables
-  </xsl:template>
+    mode="metadata-label">Tables</xsl:template>
 
 
   <xsl:template match="equation-count"
-                mode="metadata-label">Equations
-  </xsl:template>
+    mode="metadata-label">Equations</xsl:template>
 
 
   <xsl:template match="ref-count"
-                mode="metadata-label">References
-  </xsl:template>
+    mode="metadata-label">References</xsl:template>
 
 
   <xsl:template match="page-count"
-                mode="metadata-label">Pages
-  </xsl:template>
+    mode="metadata-label">Pages</xsl:template>
 
 
   <xsl:template match="word-count"
-                mode="metadata-label">Words
-  </xsl:template>
+    mode="metadata-label">Words</xsl:template>
 
 
   <xsl:template mode="metadata"
-                match="custom-meta-group">
+    match="custom-meta-group">
     <xsl:call-template name="metadata-area">
       <xsl:with-param name="label">Custom metadata</xsl:with-param>
       <xsl:with-param name="contents">
@@ -1797,8 +1790,8 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="ref-list" name="ref-list">
     <div class="section ref-list">
       <xsl:call-template name="named-anchor"/>
@@ -1812,13 +1805,13 @@
       <xsl:apply-templates select="ref-list"/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="sec-meta">
-    <div class="section-metadata">
-      <!-- includes contrib-group | permissions | kwd-group -->
-      <xsl:apply-templates/>
-    </div>
+   <div class="section-metadata">
+     <!-- includes contrib-group | permissions | kwd-group -->
+     <xsl:apply-templates/>
+   </div>
   </xsl:template>
 
 
@@ -1829,8 +1822,9 @@
 
   <xsl:template match="sec-meta/kwd-group">
     <!-- matches only if contrib-group has only contrib children -->
-    <xsl:apply-templates select="." mode="metadata"/>
+    <xsl:apply-templates  select="." mode="metadata"/>
   </xsl:template>
+
 
 
   <!-- ============================================================= -->
@@ -1838,7 +1832,7 @@
   <!-- ============================================================= -->
 
   <xsl:template name="main-title"
-                match="abstract/title | body/*/title |
+    match="abstract/title | body/*/title |
            back/title | back[not(title)]/*/title">
     <xsl:param name="contents">
       <xsl:apply-templates/>
@@ -1853,11 +1847,11 @@
 
 
   <xsl:template name="section-title"
-                match="abstract/*/title | body/*/*/title |
+    match="abstract/*/title | body/*/*/title |
 		       back[title]/*/title | back[not(title)]/*/*/title">
     <xsl:param name="contents">
       <xsl:apply-templates/>
-    </xsl:param>
+    </xsl:param>   
     <xsl:if test="normalize-space($contents)">
       <!-- coding defensively since empty titles make glitchy HTML -->
       <h3 class="section-title">
@@ -1868,11 +1862,11 @@
 
 
   <xsl:template name="subsection-title"
-                match="abstract/*/*/title | body/*/*/*/title |
+    match="abstract/*/*/title | body/*/*/*/title |
 		       back[title]/*/*/title | back[not(title)]/*/*/*/title">
     <xsl:param name="contents">
       <xsl:apply-templates/>
-    </xsl:param>
+    </xsl:param>   
     <xsl:if test="normalize-space($contents)">
       <!-- coding defensively since empty titles make glitchy HTML -->
       <h4 class="subsection-title">
@@ -1883,11 +1877,11 @@
 
 
   <xsl:template name="block-title" priority="2"
-                match="list/title | def-list/title | boxed-text/title |
+    match="list/title | def-list/title | boxed-text/title |
            verse-group/title | glossary/title | kwd-group/title">
     <xsl:param name="contents">
       <xsl:apply-templates/>
-    </xsl:param>
+    </xsl:param>   
     <xsl:if test="normalize-space($contents)">
       <!-- coding defensively since empty titles make glitchy HTML -->
       <h4 class="block-title">
@@ -1916,11 +1910,11 @@
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  Figures, lists and block-level objectS                       -->
-  <!-- ============================================================= -->
-
-
+<!-- ============================================================= -->
+<!--  Figures, lists and block-level objectS                       -->
+<!-- ============================================================= -->
+  
+  
   <xsl:template match="address">
     <xsl:choose>
       <!-- address appears as a sequence of inline elements if
@@ -1942,7 +1936,7 @@
   <xsl:template name="address-line">
     <!-- emits element children in a simple comma-delimited sequence -->
     <xsl:for-each select="*">
-      <xsl:if test="position() &gt; 1">,</xsl:if>
+      <xsl:if test="position() &gt; 1">, </xsl:if>
       <xsl:apply-templates/>
     </xsl:for-each>
   </xsl:template>
@@ -1958,8 +1952,8 @@
   <xsl:template match="alternatives">
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="array | disp-formula-group | fig-group |
     fn-group | license | long-desc | open-access | sig-block | 
     table-wrap-foot | table-wrap-group">
@@ -1967,8 +1961,8 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="attrib">
     <p class="attrib">
       <xsl:apply-templates/>
@@ -1987,17 +1981,17 @@
       <xsl:apply-templates select="." mode="label"/>
       <xsl:apply-templates/>
       <xsl:apply-templates mode="footnote"
-                           select="self::table-wrap//fn[not(ancestor::table-wrap-foot)]"/>
+        select="self::table-wrap//fn[not(ancestor::table-wrap-foot)]"/>
     </div>
   </xsl:template>
-
+  
 
   <xsl:template match="caption">
     <div class="caption">
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
+  
 
   <xsl:template match="disp-formula | statement">
     <div class="{local-name()} panel">
@@ -2006,7 +2000,7 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
+  
 
   <xsl:template match="glossary">
     <div class="glossary">
@@ -2022,14 +2016,15 @@
       <xsl:apply-templates select="*[not(self::label|self::title)]"/>
     </div>
   </xsl:template>
-
+  
 
   <xsl:template match="textual-form">
     <p class="textual-form">
-      <span class="generated">[Textual form]</span>
+      <span class="generated">[Textual form] </span>
       <xsl:apply-templates/>
     </p>
   </xsl:template>
+  
 
 
   <xsl:template match="glossary/glossary">
@@ -2038,6 +2033,7 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
+  
 
 
   <xsl:template match="graphic | inline-graphic">
@@ -2051,12 +2047,12 @@
       <xsl:call-template name="assign-src"/>
     </img>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="alt-text">
     <!-- handled with graphic or inline-graphic -->
   </xsl:template>
-
+  
 
   <xsl:template match="list">
     <div class="list">
@@ -2065,10 +2061,10 @@
       <xsl:apply-templates select="." mode="list"/>
     </div>
   </xsl:template>
-
+  
 
   <xsl:template priority="2" mode="list"
-                match="list[@list-type='simple' or list-item/label]">
+    match="list[@list-type='simple' or list-item/label]">
     <ul style="list-style-type: none">
       <xsl:apply-templates select="list-item"/>
     </ul>
@@ -2096,31 +2092,31 @@
       <xsl:apply-templates select="list-item"/>
     </ol>
   </xsl:template>
+  
+
+	<xsl:template match="list-item">
+		<li>
+			<xsl:apply-templates/>
+		</li>
+	</xsl:template>
 
 
-  <xsl:template match="list-item">
-    <li>
-      <xsl:apply-templates/>
-    </li>
-  </xsl:template>
-
-
-  <xsl:template match="list-item/label">
-    <!-- if the next sibling is a p, the label will be called as
-         a run-in -->
-    <xsl:if test="following-sibling::*[1][not(self::p)]">
-      <xsl:call-template name="label"/>
-    </xsl:if>
-  </xsl:template>
-
-
-  <xsl:template match="media">
-    <a>
-      <xsl:call-template name="assign-id"/>
-      <xsl:call-template name="assign-href"/>
-      <xsl:apply-templates/>
-    </a>
-  </xsl:template>
+	<xsl:template match="list-item/label">
+	  <!-- if the next sibling is a p, the label will be called as
+	       a run-in -->
+	  <xsl:if test="following-sibling::*[1][not(self::p)]">
+	    <xsl:call-template name="label"/>
+	  </xsl:if>
+	</xsl:template>
+  
+  
+	<xsl:template match="media">
+		<a>
+			<xsl:call-template name="assign-id"/>
+			<xsl:call-template name="assign-href"/>
+			<xsl:apply-templates/>
+		</a>
+	</xsl:template>
 
 
   <xsl:template match="p | license-p">
@@ -2133,8 +2129,8 @@
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="@content-type">
     <!-- <span class="generated">[</span>
     <xsl:value-of select="."/>
@@ -2149,7 +2145,7 @@
         <span class="label">
           <xsl:apply-templates/>
         </span>
-        <xsl:text> </xsl:text>
+      <xsl:text> </xsl:text>
       </xsl:for-each>
       <xsl:apply-templates select="@content-type"/>
       <xsl:apply-templates/>
@@ -2167,23 +2163,23 @@
 
   <xsl:template match="permissions">
     <div class="permissions">
-      <xsl:apply-templates select="copyright-statement"/>
-      <xsl:if test="copyright-year | copyright-holder">
-        <p class="copyright">
-          <span class="generated">Copyright</span>
-          <xsl:for-each select="copyright-year | copyright-holder">
+    <xsl:apply-templates select="copyright-statement"/>
+    <xsl:if test="copyright-year | copyright-holder">
+      <p class="copyright">
+        <span class="generated">Copyright</span>
+        <xsl:for-each select="copyright-year | copyright-holder">
             <xsl:apply-templates/>
             <xsl:if test="not(position()=last())">
-              <span class="generated">,</span>
+              <span class="generated">, </span>
             </xsl:if>
-          </xsl:for-each>
-        </p>
-      </xsl:if>
-      <xsl:apply-templates select="license"/>
+        </xsl:for-each>
+      </p>
+    </xsl:if>
+    <xsl:apply-templates select="license"/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="copyright-statement">
     <p class="copyright">
       <xsl:apply-templates></xsl:apply-templates>
@@ -2213,30 +2209,30 @@
   </xsl:template>
 
 
-  <xsl:template match="def-item">
-    <tr>
-      <xsl:call-template name="assign-id"/>
-      <xsl:apply-templates/>
-    </tr>
-  </xsl:template>
+	<xsl:template match="def-item">
+		<tr>
+			<xsl:call-template name="assign-id"/>
+			<xsl:apply-templates/>
+		</tr>
+	</xsl:template>
 
 
-  <xsl:template match="term">
-    <td class="def-term">
-      <xsl:call-template name="assign-id"/>
-      <p>
-        <xsl:apply-templates/>
-      </p>
-    </td>
-  </xsl:template>
+	<xsl:template match="term">
+		<td class="def-term">
+			<xsl:call-template name="assign-id"/>
+		  <p>
+				<xsl:apply-templates/>
+		  </p>
+		</td>
+	</xsl:template>
 
 
-  <xsl:template match="def">
-    <td valign="def-def">
-      <xsl:call-template name="assign-id"/>
-      <xsl:apply-templates/>
-    </td>
-  </xsl:template>
+	<xsl:template match="def">
+		<td valign="def-def">
+			<xsl:call-template name="assign-id"/>
+			<xsl:apply-templates/>
+		</td>
+	</xsl:template>
 
 
   <xsl:template match="disp-quote">
@@ -2255,22 +2251,22 @@
 
 
   <xsl:template match="ref">
-    <tr>
-      <td class="ref-label">
-        <p class="ref-label">
-          <xsl:apply-templates select="." mode="label"/>
-          <xsl:text>&#xA0;</xsl:text>
-          <!-- space forces vertical alignment of the paragraph -->
-          <xsl:call-template name="named-anchor"/>
-        </p>
-      </td>
-      <td class="ref-content">
-        <xsl:apply-templates/>
-      </td>
-    </tr>
+      <tr>
+        <td class="ref-label">
+          <p class="ref-label">
+            <xsl:apply-templates select="." mode="label"/>
+            <xsl:text>&#xA0;</xsl:text>
+            <!-- space forces vertical alignment of the paragraph -->
+            <xsl:call-template name="named-anchor"/>
+          </p>
+        </td>
+        <td class="ref-content">
+          <xsl:apply-templates/>
+        </td>
+      </tr>
   </xsl:template>
-
-
+    
+  
   <xsl:template match="ref/*" priority="0">
     <!-- should match mixed-citation, element-citation, nlm-citation.
          note and label should be matched below. -->
@@ -2279,13 +2275,13 @@
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-
-
+ 
+ 
   <xsl:template match="ref/note" priority="2">
     <xsl:param name="label" select="''"/>
     <xsl:if test="normalize-space($label) and not(preceding-sibling::*[not(self::label)])">
       <p class="label">
-        <xsl:copy-of select="$label"/>
+          <xsl:copy-of select="$label"/>
       </p>
     </xsl:if>
     <div class="note">
@@ -2293,8 +2289,8 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="app/related-article |
     app-group/related-article | bio/related-article | 
     body/related-article | boxed-text/related-article | 
@@ -2302,8 +2298,8 @@
     ref-list/related-article | sec/related-article">
     <xsl:apply-templates select="." mode="metadata"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="app/related-object |
     app-group/related-object | bio/related-object |
     body/related-object | boxed-text/related-object | 
@@ -2311,35 +2307,35 @@
     ref-list/related-object | sec/related-object">
     <xsl:apply-templates select="." mode="metadata"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="speech">
     <div class="speech">
       <xsl:call-template name="named-anchor"/>
       <xsl:apply-templates mode="speech"/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="speech/speaker" mode="speech"/>
-
-
+    
+    
   <xsl:template match="speech/p" mode="speech">
     <p>
       <xsl:apply-templates select="self::p[not(preceding-sibling::p)]/../speaker"/>
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="speech/speaker">
     <b>
       <xsl:apply-templates/>
     </b>
-    <span class="generated">:</span>
+    <span class="generated">: </span>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="supplementary-material">
     <div class="panel">
       <xsl:call-template name="named-anchor"/>
@@ -2347,16 +2343,16 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
+  
 
+	<xsl:template match="tex-math">
+		<span class="tex-math">
+			<span class="generated">[TeX:] </span>
+			<xsl:apply-templates/>
+		</span>
+	</xsl:template>
 
-  <xsl:template match="tex-math">
-    <span class="tex-math">
-      <span class="generated">[TeX:]</span>
-      <xsl:apply-templates/>
-    </span>
-  </xsl:template>
-
-
+  
   <xsl:template match="mml:*">
     <!-- this stylesheet simply copies MathML through. If your browser
          supports it, you will get it -->
@@ -2365,36 +2361,36 @@
       <xsl:apply-templates/>
     </xsl:copy>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="verse-group">
     <div class="verse">
       <xsl:call-template name="named-anchor"/>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="verse-line">
     <p class="verse-line">
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="aff/label | corresp/label |
     chem-struct/label | element-citation/label | mixed-citation/label">
     <!-- these labels appear in line -->
     <span class="generated">[</span>
     <xsl:apply-templates/>
-    <span class="generated">]</span>
+    <span class="generated">] </span>
   </xsl:template>
 
 
   <xsl:template match="app/label | boxed-text/label | chem-struct-wrap/label |
     disp-formula/label | fig/label | fn/label | ref/label |
     statement/label | supplementary-material/label | table-wrap/label"
-                priority="2">
+    priority="2">
     <!-- suppressed, since acquired by their parents in mode="label" -->
   </xsl:template>
 
@@ -2412,8 +2408,8 @@
   <!-- ============================================================= -->
   <!--  Tables are already in XHTML, and can simply be copied
         through                                                      -->
-
-
+  
+  
   <xsl:template match="table | thead | tbody | tfoot |
       col | colgroup | tr | th | td">
     <xsl:copy>
@@ -2422,27 +2418,27 @@
       <xsl:apply-templates/>
     </xsl:copy>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="array/tbody">
     <table>
       <xsl:copy>
-        <xsl:apply-templates select="@*" mode="table-copy"/>
-        <xsl:call-template name="named-anchor"/>
-        <xsl:apply-templates/>
-      </xsl:copy>
+      <xsl:apply-templates select="@*" mode="table-copy"/>
+      <xsl:call-template name="named-anchor"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
     </table>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="@*" mode="table-copy">
     <xsl:copy-of select="."/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="@content-type" mode="table-copy"/>
-
-
+  
+  
   <!-- ============================================================= -->
   <!--  INLINE MISCELLANEOUS                                         -->
   <!-- ============================================================= -->
@@ -2453,40 +2449,40 @@
   <xsl:template match="abbrev">
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+    
   <xsl:template match="abbrev/def">
     <xsl:text>[</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>]</xsl:text>
   </xsl:template>
-
+  
   <xsl:template match="p/address | license-p/address |
     named-content/p | styled-content/p">
     <xsl:apply-templates mode="inline"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="address/*" mode="inline">
     <xsl:if test="preceding-sibling::*">
-      <span class="generated">,</span>
+      <span class="generated">, </span>
     </xsl:if>
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+        
   <xsl:template match="award-id">
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+    
   <xsl:template match="award-id[normalize-space(@rid)]">
     <a href="#{@rid}">
       <xsl:apply-templates/>
     </a>
   </xsl:template>
-
-
+  
+    
   <xsl:template match="break">
     <br class="br"/>
   </xsl:template>
@@ -2498,7 +2494,7 @@
     </a>
   </xsl:template>
 
-
+  
   <xsl:template match="ext-link | uri | inline-supplementary-material">
     <a target="xrefwindow">
       <xsl:attribute name="href">
@@ -2521,16 +2517,16 @@
       <xsl:apply-templates/>
     </span>
   </xsl:template>
-
+  
 
   <xsl:template match="hr">
     <hr/>
   </xsl:template>
-
+  
 
   <!-- inline-graphic is handled above, with graphic -->
-
-
+  
+  
   <xsl:template match="inline-formula | chem-struct">
     <span class="{local-name()}">
       <xsl:apply-templates/>
@@ -2544,7 +2540,7 @@
     </div>
   </xsl:template>
 
-
+  
   <xsl:template match="milestone-start | milestone-end">
     <span class="{substring-after(local-name(),'milestone-')}">
       <xsl:comment>
@@ -2552,27 +2548,27 @@
       </xsl:comment>
     </span>
   </xsl:template>
-
+  
 
   <xsl:template match="object-id">
     <span class="{local-name()}">
       <xsl:apply-templates/>
     </span>
   </xsl:template>
-
+  
 
   <!-- preformat is handled above -->
-
+  
   <xsl:template match="sig">
     <xsl:apply-templates/>
   </xsl:template>
-
+  
 
   <xsl:template match="target">
     <xsl:call-template name="named-anchor"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="styled-content">
     <span>
       <xsl:copy-of select="@style"/>
@@ -2584,8 +2580,8 @@
       <xsl:apply-templates/>
     </span>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="named-content">
     <span>
       <xsl:for-each select="@content-type">
@@ -2596,8 +2592,8 @@
       <xsl:apply-templates/>
     </span>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="private-char">
     <span>
       <xsl:for-each select="@description">
@@ -2605,7 +2601,7 @@
           <xsl:value-of select="."/>
         </xsl:attribute>
       </xsl:for-each>
-      <span class="generated">[Private character</span>
+      <span class="generated">[Private character </span>
       <xsl:for-each select="@name">
         <xsl:text> </xsl:text>
         <xsl:value-of select="."/>
@@ -2613,37 +2609,37 @@
       <span class="generated">]</span>
     </span>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="glyph-data | glyph-ref">
     <span class="generated">(Glyph not rendered)</span>
   </xsl:template>
-
-
+    
+  
   <xsl:template match="related-article">
-    <span class="generated">[Related article:]</span>
+    <span class="generated">[Related article:] </span>
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="related-object">
-    <span class="generated">[Related object:]</span>
+    <span class="generated">[Related object:] </span>
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="xref[not(normalize-space())]">
-    <xsl:choose>
-      <xsl:when test="@ref-type='aff' and count(/article/front/article-meta//aff)=1"/>
-      <xsl:otherwise>
-        <a href="#{@rid}">
-          <xsl:apply-templates select="key('element-by-id',@rid)"
-                               mode="label-text">
-            <xsl:with-param name="warning" select="true()"/>
-          </xsl:apply-templates>
-        </a>
-      </xsl:otherwise>
-    </xsl:choose>
+  	<xsl:choose>
+  		<xsl:when test="@ref-type='aff' and count(/article/front/article-meta//aff)=1"/>
+  		<xsl:otherwise>
+		    <a href="#{@rid}">
+		      <xsl:apply-templates select="key('element-by-id',@rid)"
+		        mode="label-text">
+		        <xsl:with-param name="warning" select="true()"/>
+		      </xsl:apply-templates>
+		    </a>
+  		</xsl:otherwise>
+  	</xsl:choose>
   </xsl:template>
 
 
@@ -2654,6 +2650,7 @@
   </xsl:template>
 
 
+  
   <!-- ============================================================= -->
   <!--  Formatting elements                                          -->
   <!-- ============================================================= -->
@@ -2749,9 +2746,9 @@
 
 
   <xsl:variable name="loose-footnotes"
-                select="//fn[not(ancestor::front|parent::fn-group|ancestor::table-wrap)]"/>
-
-
+    select="//fn[not(ancestor::front|parent::fn-group|ancestor::table-wrap)]"/>
+    
+    
   <xsl:template name="make-back">
     <xsl:apply-templates select="back"/>
     <xsl:if test="$loose-footnotes and not(back)">
@@ -2760,7 +2757,7 @@
       <xsl:call-template name="footnotes"/>
     </xsl:if>
   </xsl:template>
-
+    
   <xsl:template match="back">
     <!-- content model for back: 
           (label?, title*, 
@@ -2771,8 +2768,8 @@
     </xsl:if>
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+  
   <xsl:template name="footnotes">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Notes</xsl:with-param>
@@ -2781,42 +2778,42 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="ack">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Acknowledgements</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template match="app-group">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Appendices</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template match="back/bio">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Biography</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template match="back/fn-group">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Notes</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="back/glossary">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Glossary</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template match="back/ref-list">
     <xsl:call-template name="backmatter-section">
@@ -2826,14 +2823,14 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="back/notes">
     <xsl:call-template name="backmatter-section">
       <xsl:with-param name="generated-title">Notes</xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template name="backmatter-section">
     <xsl:param name="generated-title"/>
@@ -2861,20 +2858,20 @@
       <xsl:copy-of select="$contents"/>
     </div>
   </xsl:template>
-
+  
 
   <!-- ============================================================= -->
   <!--  FOOTNOTES                                                    -->
   <!-- ============================================================= -->
 
   <xsl:template match="fn">
-    <!-- Footnotes appearing outside fn-group
-         generate cross-references to the footnote,
-         which is displayed elsewhere -->
-    <!-- Note the rules for displayed content: if any fn elements
-         not inside an fn-group (the matched fn or any other) includes
-         a label child, all footnotes are expected to have a label
-         child. -->
+  <!-- Footnotes appearing outside fn-group
+       generate cross-references to the footnote,
+       which is displayed elsewhere -->
+  <!-- Note the rules for displayed content: if any fn elements
+       not inside an fn-group (the matched fn or any other) includes
+       a label child, all footnotes are expected to have a label
+       child. -->
     <xsl:variable name="id">
       <xsl:apply-templates select="." mode="id"/>
     </xsl:variable>
@@ -2884,21 +2881,21 @@
       </xsl:apply-templates>
     </a>
   </xsl:template>
-
+  
   <xsl:template match="fn-group/fn | table-wrap-foot/fn |
                        table-wrap-foot/fn-group/fn">
     <xsl:apply-templates select="." mode="footnote"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="fn" mode="footnote">
     <div class="footnote">
       <xsl:call-template name="named-anchor"/>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="fn/p">
     <p>
       <xsl:call-template name="assign-id"/>
@@ -2909,8 +2906,8 @@
       <xsl:apply-templates/>
     </p>
   </xsl:template>
-
-
+  
+  
   <!-- ============================================================= -->
   <!--  MODE 'label-text'
 	      Generates label text for elements and their cross-references -->
@@ -2962,30 +2959,30 @@
   <xsl:variable name="auto-label-fig" select="false()"/>
   <xsl:variable name="auto-label-ref" select="not(//ref[label])"/>
   <!-- ref elements are labeled unless any ref already has a label -->
-
+  
   <xsl:variable name="auto-label-statement" select="false()"/>
   <xsl:variable name="auto-label-supplementary"
-                select="false()"/>
+    select="false()"/>
   <xsl:variable name="auto-label-table-wrap" select="false()"/>
 
-  <!--
-    These variables assignments show how autolabeling can be
-    configured conditionally.
-    For example: "label figures if no figures have labels" translates to
-      "not(//fig[label])", which will resolve to Boolean true() when the set of
-      all fig elements with labels is empty.
-
-    <xsl:variable name="auto-label-app" select="not(//app[label])"/>
-    <xsl:variable name="auto-label-boxed-text" select="not(//boxed-text[label])"/>
-    <xsl:variable name="auto-label-chem-struct-wrap" select="not(//chem-struct-wrap[label])"/>
-    <xsl:variable name="auto-label-disp-formula" select="not(//disp-formula[label])"/>
-    <xsl:variable name="auto-label-fig" select="not(//fig[label])"/>
-    <xsl:variable name="auto-label-ref" select="not(//ref[label])"/>
-    <xsl:variable name="auto-label-statement" select="not(//statement[label])"/>
-    <xsl:variable name="auto-label-supplementary"
-      select="not(//supplementary-material[not(ancestor::front)][label])"/>
-    <xsl:variable name="auto-label-table-wrap" select="not(//table-wrap[label])"/>
-  -->
+<!--
+  These variables assignments show how autolabeling can be 
+  configured conditionally.
+  For example: "label figures if no figures have labels" translates to
+    "not(//fig[label])", which will resolve to Boolean true() when the set of
+    all fig elements with labels is empty.
+  
+  <xsl:variable name="auto-label-app" select="not(//app[label])"/>
+  <xsl:variable name="auto-label-boxed-text" select="not(//boxed-text[label])"/>
+  <xsl:variable name="auto-label-chem-struct-wrap" select="not(//chem-struct-wrap[label])"/>
+  <xsl:variable name="auto-label-disp-formula" select="not(//disp-formula[label])"/>
+  <xsl:variable name="auto-label-fig" select="not(//fig[label])"/>
+  <xsl:variable name="auto-label-ref" select="not(//ref[label])"/>
+  <xsl:variable name="auto-label-statement" select="not(//statement[label])"/>
+  <xsl:variable name="auto-label-supplementary"
+    select="not(//supplementary-material[not(ancestor::front)][label])"/>
+  <xsl:variable name="auto-label-table-wrap" select="not(//table-wrap[label])"/>
+-->  
 
   <xsl:template mode="label" match="*" name="block-label">
     <xsl:param name="contents">
@@ -2993,7 +2990,7 @@
         <!-- we place a warning for missing labels if this element is ever
              cross-referenced with an empty xref -->
         <xsl:with-param name="warning"
-                        select="boolean(key('xref-by-rid',@id)[not(normalize-space())])"/>
+          select="boolean(key('xref-by-rid',@id)[not(normalize-space())])"/>
       </xsl:apply-templates>
     </xsl:param>
     <xsl:if test="normalize-space($contents)">
@@ -3011,13 +3008,13 @@
     </xsl:param>
     <xsl:if test="normalize-space($contents)">
       <!-- we're already in a p -->
-      <span class="label">
-        <xsl:copy-of select="$contents"/>
-      </span>
+        <span class="label">
+          <xsl:copy-of select="$contents"/>
+        </span>
     </xsl:if>
   </xsl:template>
 
-
+  
   <xsl:template match="app" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
@@ -3033,7 +3030,7 @@
       </xsl:with-param>-->
     </xsl:call-template>
   </xsl:template>
-
+  
 
   <xsl:template match="boxed-text" mode="label-text">
     <xsl:param name="warning" select="true()"/>
@@ -3049,7 +3046,7 @@
     </xsl:call-template>
   </xsl:template>
 
-
+  
   <xsl:template match="disp-formula" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
@@ -3100,7 +3097,7 @@
     <!-- pass $warning in as false() if a warning string is not wanted
          (for example, if generating autonumbered labels) -->
     <xsl:variable name="auto-number-fn"
-                  select="not(ancestor::front//fn/label | ancestor::front//fn/@symbol)"/>
+      select="not(ancestor::front//fn/label | ancestor::front//fn/@symbol)"/>
     <xsl:call-template name="make-label-text">
       <xsl:with-param name="auto" select="$auto-number-fn"/>
       <xsl:with-param name="warning" select="$warning"/>
@@ -3111,14 +3108,14 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="table-wrap//fn" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
          (for example, if generating autonumbered labels) -->
     <xsl:variable name="auto-number-fn"
-                  select="not(ancestor::table-wrap//fn/label | ancestor::table-wrap//fn/@symbol)"/>
+      select="not(ancestor::table-wrap//fn/label | ancestor::table-wrap//fn/@symbol)"/>
     <xsl:call-template name="make-label-text">
       <xsl:with-param name="auto" select="$auto-number-fn"/>
       <xsl:with-param name="warning" select="$warning"/>
@@ -3129,14 +3126,14 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="fn" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
          (for example, if generating autonumbered labels) -->
     <xsl:variable name="auto-number-fn"
-                  select="not(ancestor::article//fn[not(ancestor::front|ancestor::table-wrap)]/label |
+      select="not(ancestor::article//fn[not(ancestor::front|ancestor::table-wrap)]/label |
                   ancestor::article//fn[not(ancestor::front|ancestor::table-wrap)]/@symbol)"/>
     <xsl:call-template name="make-label-text">
       <xsl:with-param name="auto" select="$auto-number-fn"/>
@@ -3144,7 +3141,7 @@
       <xsl:with-param name="auto-text">
         <xsl:text>[</xsl:text>
         <xsl:number level="any" count="fn[not(ancestor::front)]"
-                    from="article | sub-article | response"/>
+        from="article | sub-article | response"/>
         <xsl:text>]</xsl:text>
       </xsl:with-param>
     </xsl:call-template>
@@ -3173,13 +3170,13 @@
       <xsl:with-param name="auto" select="$auto-label-statement"/>
       <xsl:with-param name="warning" select="$warning"/>
       <xsl:with-param name="auto-text">
-        <xsl:text>Statement </xsl:text>
+          <xsl:text>Statement </xsl:text>
         <xsl:number level="any"/>
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+ 
   <xsl:template match="supplementary-material" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
@@ -3188,14 +3185,14 @@
       <xsl:with-param name="auto" select="$auto-label-supplementary"/>
       <xsl:with-param name="warning" select="$warning"/>
       <xsl:with-param name="auto-text">
-        <xsl:text>Supplementary Material </xsl:text>
+          <xsl:text>Supplementary Material </xsl:text>
         <xsl:number level="any" format="A"
-                    count="supplementary-material[not(ancestor::front)]"/>
+          count="supplementary-material[not(ancestor::front)]"/>
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+ 
   <xsl:template match="table-wrap" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
@@ -3209,8 +3206,8 @@
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+ 
   <xsl:template match="*" mode="label-text">
     <xsl:param name="warning" select="true()"/>
     <!-- pass $warning in as false() if a warning string is not wanted
@@ -3219,32 +3216,32 @@
       <xsl:with-param name="warning" select="$warning"/>
     </xsl:call-template>
   </xsl:template>
-
-
+  
+ 
   <xsl:template match="label" mode="label-text">
     <xsl:apply-templates mode="inline-label-text"/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="text()" mode="inline-label-text">
     <!-- when displaying labels, space characters become non-breaking spaces -->
     <xsl:value-of select="translate(normalize-space(.),' &#xA;&#x9;','&#xA0;&#xA0;&#xA0;')"/>
   </xsl:template>
+  
 
-
-  <!-- ============================================================= -->
-  <!--  Writing a name                                               -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  Writing a name                                               -->
+<!-- ============================================================= -->
 
   <!-- Called when displaying structured names in metadata         -->
 
   <xsl:template name="write-name" match="name">
     <xsl:apply-templates select="prefix" mode="inline-name"/>
     <xsl:apply-templates select="surname[../@name-style='eastern']"
-                         mode="inline-name"/>
+      mode="inline-name"/>
     <xsl:apply-templates select="given-names" mode="inline-name"/>
     <xsl:apply-templates select="surname[not(../@name-style='eastern')]"
-                         mode="inline-name"/>
+      mode="inline-name"/>
     <xsl:apply-templates select="suffix" mode="inline-name"/>
   </xsl:template>
 
@@ -3285,22 +3282,22 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-
+  
   <!-- string-name elements are written as is -->
-
+  
   <xsl:template match="string-name">
     <xsl:apply-templates/>
   </xsl:template>
-
-
+  
+  
   <xsl:template match="string-name/*">
     <xsl:apply-templates/>
   </xsl:template>
-
-
-  <!-- ============================================================= -->
-  <!--  UTILITY TEMPLATES                                           -->
-  <!-- ============================================================= -->
+  
+  
+<!-- ============================================================= -->
+<!--  UTILITY TEMPLATES                                           -->
+<!-- ============================================================= -->
 
 
   <xsl:template name="append-pub-type">
@@ -3391,11 +3388,11 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates mode="label-text"
-                             select="label | @symbol"/>
+          select="label | @symbol"/>
         <xsl:if test="$warning and not(label|@symbol)">
           <span class="warning">
             <xsl:text>{ label</xsl:text>
-            <xsl:if test="self::fn">(or @symbol)</xsl:if>
+            <xsl:if test="self::fn"> (or @symbol)</xsl:if>
             <xsl:text> needed for </xsl:text>
             <xsl:value-of select="local-name()"/>
             <xsl:for-each select="@id">
@@ -3449,16 +3446,16 @@
       </xsl:if>
     </xsl:variable>
     <a name="{$id}">
-      <xsl:comment>named anchor</xsl:comment>
+      <xsl:comment> named anchor </xsl:comment>
     </a>
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  Process warnings                                             -->
-  <!-- ============================================================= -->
-  <!-- Generates a list of warnings to be reported due to processing
-       anomalies. -->
+<!-- ============================================================= -->
+<!--  Process warnings                                             -->
+<!-- ============================================================= -->
+<!-- Generates a list of warnings to be reported due to processing
+     anomalies. -->
 
   <xsl:template name="process-warnings">
     <!-- returns an RTF containing all the warnings -->
@@ -3466,11 +3463,11 @@
       <xsl:for-each select="//xref[not(normalize-space())]">
         <xsl:variable name="target-label">
           <xsl:apply-templates select="key('element-by-id',@rid)"
-                               mode="label-text">
+            mode="label-text">
             <xsl:with-param name="warning" select="false()"/>
           </xsl:apply-templates>
         </xsl:variable>
-
+      	
         <xsl:if test="not(normalize-space($target-label)) and @ref-type!='aff'
         	or not(normalize-space($target-label)) and @ref-type='aff' 
         	and count(/article/front/article-meta//aff) > 1">
@@ -3479,7 +3476,7 @@
                we ask again to get the warning -->
           <li>
             <xsl:apply-templates select="key('element-by-id',@rid)"
-                                 mode="label-text">
+              mode="label-text">
               <xsl:with-param name="warning" select="true()"/>
             </xsl:apply-templates>
           </li>
@@ -3490,20 +3487,21 @@
     <xsl:if test="normalize-space($xref-warnings)">
       <h4>Elements are cross-referenced without labels.</h4>
       <p>Either the element should be provided a label, or their cross-reference(s) should
-        have literal text content.
-      </p>
+        have literal text content.</p>
       <ul>
         <xsl:copy-of select="$xref-warnings"/>
       </ul>
     </xsl:if>
   </xsl:template>
+  
+        
+   
 
-
-  <!-- ============================================================= -->
-  <!--  id mode                                                      -->
-  <!-- ============================================================= -->
-  <!-- An id can be derived for any element. If an @id is given,
-       it is presumed unique and copied. If not, one is generated.   -->
+<!-- ============================================================= -->
+<!--  id mode                                                      -->
+<!-- ============================================================= -->
+<!-- An id can be derived for any element. If an @id is given,
+     it is presumed unique and copied. If not, one is generated.   -->
 
   <xsl:template match="*" mode="id">
     <xsl:value-of select="@id"/>
@@ -3518,15 +3516,15 @@
     <xsl:if test="not(@id)">
       <xsl:value-of select="local-name()"/>
       <xsl:number from="article" level="multiple"
-                  count="article | sub-article | response" format="1-1"/>
+        count="article | sub-article | response" format="1-1"/>
     </xsl:if>
   </xsl:template>
 
 
-  <!-- ============================================================= -->
-  <!--  "format-date"                                                -->
-  <!-- ============================================================= -->
-  <!-- Maps a structured date element to a string -->
+<!-- ============================================================= -->
+<!--  "format-date"                                                -->
+<!-- ============================================================= -->
+<!-- Maps a structured date element to a string -->
 
   <xsl:template name="format-date">
     <!-- formats date in DD Month YYYY format -->
@@ -3565,32 +3563,32 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+  
 
-
-  <!-- ============================================================= -->
-  <!--  "author-string" writes authors' names in sequence            -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  "author-string" writes authors' names in sequence            -->
+<!-- ============================================================= -->
 
   <xsl:template name="author-string">
     <xsl:variable name="all-contribs"
-                  select="/article/front/article-meta/contrib-group/contrib/name/surname |
+      select="/article/front/article-meta/contrib-group/contrib/name/surname |
               /article/front/article-meta/contrib-group/contrib/collab"/>
-    <xsl:for-each select="$all-contribs">
+   <xsl:for-each select="$all-contribs">
       <xsl:if test="count($all-contribs) &gt; 1">
         <xsl:if test="position() &gt; 1">
           <xsl:if test="count($all-contribs) &gt; 2">,</xsl:if>
           <xsl:text> </xsl:text>
         </xsl:if>
-        <xsl:if test="position() = count($all-contribs)">and</xsl:if>
+        <xsl:if test="position() = count($all-contribs)">and </xsl:if>
       </xsl:if>
       <xsl:value-of select="."/>
     </xsl:for-each>
   </xsl:template>
+  
 
-
-  <!-- ============================================================= -->
-  <!--  Footer branding                                              -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  Footer branding                                              -->
+<!-- ============================================================= -->
 
   <xsl:template name="footer-branding">
     <hr class="part-rule"/>
@@ -3605,8 +3603,8 @@
     </div>
   </xsl:template>
 
-  <!-- ============================================================= -->
-  <!--  End stylesheet                                               -->
-  <!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--  End stylesheet                                               -->
+<!-- ============================================================= -->
 
 </xsl:stylesheet>


### PR DESCRIPTION
Re-forked article-transform.xsl from current Ambra implementation; new copy
in desktop theme does not have new tweaks introduced specifically for the
mobile page. There is substantial duplication with the mobile copy of the
file, which we might try to tame later. Also pulled jpub3-html.xsl up into
the root theme for reuse.

Added placeholder files for FreeMarker entry points named in
ArticleController, with placeholder code. Basic article pages should now be
viewable (but unimplemented) on desktop-based themes without any errors
being thrown.
