### PR TITLE
DPRO-297- creating a function for drop down.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/common/siteMenu/siteMenu.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/common/siteMenu/siteMenu.ftl
@@ -59,4 +59,5 @@ MARKUP: using Foundation Top Bar for navigation -->
 </#if>
 
 <@js src="resource/js/vendor/jquery.hoverIntent.js"/>
+<@js src="resource/js/vendor/menu_drop.js"/>
 <@js src="resource/js/components/hover_delay.js"/>

--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/hover_delay.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/hover_delay.js
@@ -2,61 +2,37 @@
  * Created by pgrinbaum on 7/17/
 
  * requires:  hoverIntent
+ * requires: menu_drop
  */
 
-//  Menu Function
-(function ($) {
-
-  $.fn.menuDrop = function (action, options) {
-    options = $.extend({}, defaults, options);
-
-    var defaults = {
-      child: '.dropdown'
-    };
-
-    if (action === "show") {
-      this.addClass("hover");
-      $(options.child, this).css('visibility', 'visible');
-      return this;
-    }
-
-    if (action === "hide") {
-      this.removeClass("hover");
-      $(options.child, this).css('visibility', 'hidden');
-      return this;
-    }
-
-  };
-
-}(jQuery));
 
 hover_delay = {
 
   init: function () {
     // kick things off
-    var $dropdown = $('li.has-dropdown');
+    var $menu_drop_selector = $('li.has-dropdown');
     // if mobile, use modernizer to check for touch events. If so then:
 //      1. add needsclick class so fastclick won't do it's magic
 //      2. use hover instead of hoverIntent - hoverIntent adds timing to the hover we don't want for touch devices. '
     // 3. we need to invoke the hide action AFTER the click because safari on mobile will persist hover state when you go to another page.
 
     if ($('html.touch').length) {
-      $dropdown.
+      $menu_drop_selector.
           addClass('needsclick').
           hover(
-            function () {$(this).menuDrop("show");},
-            function () {$(this).menuDrop("hide");}
+            function () {$(this).menu_drop("show");},
+            function () {$(this).menu_drop("hide");}
           );
       // invoke the hide menu
       $('.dropdown a').on({ 'click':
           function () {
-            $.Deferred().done($dropdown.menuDrop("hide"));}
+            $.Deferred().done($menu_drop_selector.menu_drop("hide"));}
       });
     } else {
       //HoverIntent.js is used for the main navigation delay on hover
-      $dropdown.hoverIntent(
-          function () {$(this).menuDrop("show");},
-          function () {$(this).menuDrop("hide");}
+      $menu_drop_selector.hoverIntent(
+          function () {$(this).menu_drop("show");},
+          function () {$(this).menu_drop("hide");}
       );
     }
   }

--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/menu_drop.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/menu_drop.js
@@ -1,0 +1,31 @@
+/**
+ * Created by pgrinbaum on 8/12/14.
+ */
+
+//  sets hover state and visibility
+//
+
+(function ($) {
+
+  $.fn.menu_drop = function (action, options) {
+    options = $.extend({}, defaults, options);
+
+    var defaults = {
+      child: '.dropdown'
+    };
+
+    if (action === "show") {
+      this.addClass("hover");
+      $(options.child, this).css('visibility', 'visible');
+      return this;
+    }
+
+    if (action === "hide") {
+      this.removeClass("hover");
+      $(options.child, this).css('visibility', 'hidden');
+      return this;
+    }
+
+  };
+
+}(jQuery));


### PR DESCRIPTION
This is more of a code review then a pull request. 

in order to avoid repeating myself with the defer method for mobile. I had to create a jquery function- or it just seemed the most pertinent solution.  I HATE the fact that  now we have to add all those function calls but i can't see a way around it. 

Also this thing seems like it's going to be reused when we do dropdowns on the article page. 

so my questions are:
- naming do my names make sense?
  - this is creating a pattern, is it one we like?
  - in relation the pattern comment, should I pull the function into another file? like we do with other jquery plugins that we DIDN't build?
- I was going to extend this further for example making the click selector part of the function but it seemed to make more sense to wait until we do the dropdown on the article page then we have more examples of edge cases. 
