### PR TITLE
DPRO-400: Add unstyled markup for Print button

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/print.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/print.ftl
@@ -1,0 +1,12 @@
+<span>Print</span><#-- TODO: Style as button -->
+<span><#-- TODO: Code as dropdown when button is hovered over -->
+  <ul>
+    <li>
+      <a title="Print Article"
+         onclick="window.print(); return false;">
+        Print article
+      </a>
+    </li>
+  <#include "printService.ftl" />
+  </ul>
+</span>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/printService.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/printService.ftl
@@ -1,0 +1,1 @@
+<#-- Override hook for adding a link to a third-party print service. -->

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/sidebar.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/sidebar.ftl
@@ -1,1 +1,2 @@
 <#include "downloads.ftl" />
+<#include "print.ftl" />


### PR DESCRIPTION
Depends on https://github.com/PLOS/rhino/pull/40

This just places the markup for the print buttons, but they lack styling and drop-down behavior. Please do not resolve the ticket after accepting.
