### PR TITLE
DPRO-401

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/share.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/share.ftl
@@ -1,7 +1,6 @@
 <#setting url_escaping_charset="UTF-8">
-<#assign urlFix = article.url?url,
-titleFix = article.title?replace("<[^>]*>", "", "r"),
-noRedirectUrl = "http://www."+journalStyle+".org/article/info:doi/"+articleDoi/>
+<#assign urlFix = "http://dx.doi.org/${article.doi}"?url,
+titleFix = article.title?replace("<[^>]*>", "", "r") />
 
 <div class="share-article" id="shareArticle" data-js-tooltip-hover="trigger">
   Share
@@ -11,20 +10,16 @@ noRedirectUrl = "http://www."+journalStyle+".org/article/info:doi/"+articleDoi/>
     <li><a href="http://www.reddit.com/submit?url=${urlFix}" id="shareReddit" target="_blank" title="Submit to Reddit"><img src="<@siteLink path="/resource/img/icon.reddit.16.png"/>" width="16" height="16" alt="Reddit">Reddit</a></li>
 
   <#-- google plus, as per <https://developers.google.com/+/plugins/share/#sharelink>  -->
-    <li><a href="https://plus.google.com/share?url=${urlFix}"  id="shareGoogle" target="_blank" title="Share on Google+"><img src="<@siteLink path="/resource/img/icon.gplus.16.png"/>" width="16" height="16" alt="Google+">Google+</a></li>
+    <li><a href="https://plus.google.com/share?url=${urlFix}" id="shareGoogle" target="_blank" title="Share on Google+"><img src="<@siteLink path="/resource/img/icon.gplus.16.png"/>" width="16" height="16" alt="Google+">Google+</a></li>
 
   <#-- stumbleupon, as per previous implementation. no current public
   documentation can be found on their site or elsewhere. -->
-    <li><a href="http://www.stumbleupon.com/submit?url=${noRedirectUrl}"  id="shareStumble" target="_blank" title="Add to StumbleUpon"><img src="<@siteLink path="/resource/img/icon.stumble.16.png"/>" width="16" height="16" alt="StumbleUpon">StumbleUpon</a></li>
+    <li><a href="http://www.stumbleupon.com/submit?url=${urlFix}"  id="shareStumble" target="_blank" title="Add to StumbleUpon"><img src="<@siteLink path="/resource/img/icon.stumble.16.png"/>" width="16" height="16" alt="StumbleUpon">StumbleUpon</a></li>
 
   <#-- facebook, as per previous implementation which uses the now
   deprecated share.php (which redirects to /sharer/sharer.php) -->
-    <li><a href="http://www.facebook.com/share.php?u=${urlFix}&amp;t=${titleFix}" id="shareFacebook" target="_blank" title="Share on Facebook"><img src="<@siteLink path="/resource/img/icon.fb.16.png"/>" width="16" height="16" alt="Facebook">Facebook</a></li>
+    <li><a href="http://www.facebook.com/share.php?u=${urlFix}&t=${titleFix}" id="shareFacebook" target="_blank" title="Share on Facebook"><img src="<@siteLink path="/resource/img/icon.fb.16.png"/>" width="16" height="16" alt="Facebook">Facebook</a></li>
 
-
-
-   <#include 'shareInserts.ftl' />
+  <#include 'shareInserts.ftl' />
   </ul>
 </div>
-
-


### PR DESCRIPTION
fixed the issue where the doi in the link was being double url encoded.
changed the stumbleupon link to the doi resolver link

https://github.com/PLOS/plos-themes/pull/192
