### PR TITLE
DPRO-545: Decouple from article XML naming convention

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
@@ -482,7 +482,7 @@ public class ArticleController extends WombatController {
    * @return the service path to the correspond article XML asset file
    */
   private static String getArticleXmlAssetPath(String articleId) {
-    return "assetfiles/" + articleId + ".XML";
+    return "articles/" + articleId + "?xml";
   }
 
   /**


### PR DESCRIPTION
**Caution**: Depends on https://github.com/PLOS/rhino/pull/52

Solves a bug where the correctness of a service request relies on an article-to-asset naming convention that Rhino ought to obscure. This filename used to be, undocumentedly, case-insensitive, but the content repo migration breaks this assumption in certain conditions.

This patch breaks the dependence entirely by using a new service that requires only an article DOI, not an article XML filename.

Please don't move the DPRO-545 ticket in association with this pull request. This is just a small subtask associated with much larger changes further down the stack. (In fact, there shouldn't _have_ to be any changes in this part of the stack; that's the bug we're fixing.)
