### PR TITLE
DPRO-709: Fix figure lightbox failing to find div.figure

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/article_lightbox.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/article_lightbox.js
@@ -79,7 +79,7 @@
           var article_title = $(data).find('#artTitle').text();
           var authors = $(data).find('.author-name');
           var auth_list = $(authors).text();
-          var article_body = $(data).find('#artText').html();
+          var article_body = $(data).find('#artText');
           var abstract_data = $(data).find('.abstract');
           var abstract_info = $(data).find('.articleinfo');
           FVBuildHdr(article_title, auth_list, doi, state);
@@ -300,7 +300,7 @@
       return '#' + uri;
     };
 
-    fig_container = $(data).find('.figure');
+    fig_container = data.find('.figure');
 
     //iterate through each image
     $.each(fig_container, function () {


### PR DESCRIPTION
Prior to this change, `$(data).find('#artText').html()` passes in only the contents of the `#artText` element, not the element itself. Hence `$(data).find('.figure')` would iterate over each child element of `#artText` and look for `.figure` within each of those children. Thus it worked on most articles (where the `.figure`s would be children of a section) but not on http://one-dpro2.plosjournals.org/wombat/DesktopPlosBiology/article?id=10.1371/journal.pbio.1002025 where the only `.figure` happens to be a direct child of `#artText` itself.
