### PR TITLE
DPRO-657 DPRO-587 - issues relating to bold

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -2494,7 +2494,7 @@
     <a href="#{translate(@rid, '.', '-')}">
       <xsl:apply-templates/>
     </a>
-  </xsl:template
+  </xsl:template>
   <!-- 1/4/12: Ambra modifications (transform to <strong> instead of <b>) -->
   <xsl:template match="bold">
     <strong>


### PR DESCRIPTION
for a fix to DPRO-450 we removed bolding all elements in an effort to
remove the extraneous tags from table headers. This adds back the bold
tags and only removes them when they appear in th tags.

NOTE: this fixes both : DPRO-657 - DPRO-587
