### PR TITLE
DPRO-706 - fixing scrolling of references for iPad

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/article_lightbox.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/article_lightbox.js
@@ -17,9 +17,9 @@
   lightbox.FigViewerInit = function(doi, ref, state, external_page) {
     var rerunMathjax, loadJSON;
 
-    //disable scrolling on web page behind fig viewer
-    $('body').css('overflow', 'hidden');
-    $('body').on('touchmove', function(e){e.preventDefault()});
+    //disable scrolling on web page behind fig viewer except for the references which need to scroll
+    $('body').css('overflow', 'hidden').addClass('stop-scroll');
+
     $('#fig-viewer').foundation('reveal', 'open', {
       url: 'article/lightbox',
       success: function(data) {
@@ -952,7 +952,7 @@
   var FVClose = function() {
 
     //re-enable scrolling
-    $('body').css('overflow','auto').off('touchmove');
+    $('body').css('overflow','auto').removeClass('stop-scroll');
     //reset the foundation tabs
     $('.fv-nav').find('li').removeClass('active');
 

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_article-lightbox.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_article-lightbox.scss
@@ -20,6 +20,10 @@ $fv-grey-light: #eae9e9;
 $fv-grey-bg: darken($grey-light, 3%);
 // using the following until the variables get sorted out.
 
+html.touch .stop-scroll{
+   position: fixed;
+}
+
 #fig-viewer {
   background: rgba(0,0,0,0.8);
   position: fixed;


### PR DESCRIPTION
It appears that making the body fixed while having the fig viewer open
allows things to scroll automatically on iPad. Alternately this also
fixed the problem of the fig-viewer appearing slightly smaller than the
viewport on ipads.
I am assuming that since this is how lightbox works on Ambra, this is
how we want it to work.

We may want to hold off merging this into master until 665 is ready since this uses the lightbox code in master. 
