### PR TITLE
DPRO-678: Updated jquery.dotdotdot.js with latest version and bug fix

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/vendor/jquery.dotdotdot.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/vendor/jquery.dotdotdot.js
@@ -1,5 +1,5 @@
 /*
- *	jQuery dotdotdot 1.6.14
+ *	jQuery dotdotdot 1.6.16
  *
  *	Copyright (c) Fred Heusschen
  *	www.frebsite.nl
@@ -83,7 +83,9 @@
 						.detach()
 						.end()
 						.append( orgContent.clone( true ) )
-						.find( 'br' ).replaceWith( '  <br />  ' ).end()
+						.find( 'br' )
+						.replaceWith( '  <br />  ' )
+						.end()
 						.css({
 							'height'	: 'auto',
 							'width'		: 'auto',
@@ -342,7 +344,13 @@
 		var notx = 'table, thead, tbody, tfoot, tr, col, colgroup, object, embed, param, ol, ul, dl, blockquote, select, optgroup, option, textarea, script, style';
 
 		//	Don't remove these elements even if they are after the ellipsis
-		var noty = 'script';
+		var noty = 'script, .dotdotdot-keep';
+
+		var addAfter = function(elem) {
+			if ( after ) {
+				elem[ elem.is( notx ) ? 'after' : 'append' ]( after );
+			}
+		};
 
 		$elem
 			.contents()
@@ -369,10 +377,7 @@
 					else
 					{
 						$elem.append( $e );
-						if ( after )
-						{
-							$elem[ $elem.is( notx ) ? 'after' : 'append' ]( after );
-						}
+						addAfter( $elem );
 						if ( test( $i, o ) )
 						{
 							if ( e.nodeType == 3 ) // node is TEXT
@@ -386,7 +391,7 @@
 
 							if ( !isTruncated )
 							{
-								$e.detach();
+								addAfter($($elem.contents().last()));
 								isTruncated = true;
 							}
 						}


### PR DESCRIPTION
Current version: 1.6.14
New version: 1.6.16

Bug fix: taken from forked branch akalinovskiy:master addresses the behavior seen here (entire figure description paragraph deleted in some cases). See https://github.com/BeSite/jQuery.dotdotdot/pull/46

Manually tested the only other use of this library in Wombat (truncation of long article titles in home page recent articles list), and no regressions were observed.
