### PR TITLE
DPRO-686: Fixed '...show more' styling in figure lightbox

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_article-lightbox.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_article-lightbox.scss
@@ -227,6 +227,7 @@ $fv-grey-bg: darken($grey-light, 3%);
 #fig-viewer-slides .txt .more {
   padding: 0 5% $pad-smallish 3.1%;
   font-weight: normal;
+  font-style: normal;
   text-decoration: underline;
   color: $plos-default;
   margin-top: 1px;


### PR DESCRIPTION
This was part of a commit on DPRO-678 but got clobbered somehow, perhaps through a subsequent merge.
