### PR TITLE
DPRO-788: Don't show a 404 page if only article XML is missing

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
@@ -95,12 +95,7 @@ public class ArticleController extends WombatController {
     RenderContext renderContext = new RenderContext(site);
     renderContext.setArticleId(articleId);
 
-    String articleHtml;
-    try {
-      articleHtml = getArticleHtml(renderContext);
-    } catch (EntityNotFoundException enfe) {
-      throw new ArticleNotFoundException(articleId);
-    }
+    String articleHtml = getArticleHtml(renderContext);
     model.addAttribute("article", articleMetadata);
     model.addAttribute("categoryTerms", getCategoryTerms(articleMetadata));
     model.addAttribute("articleText", articleHtml);


### PR DESCRIPTION
Removed a "catch (EntityNotFoundException)" block. At that point, article
existence has already been checked, so an EntityNotFoundException indicates
an invalid data condition where the article is in Rhino's database but the
XML file is missing. In this case it is more useful to indicate a
server-side error than to report a 404.
