### PR TITLE
DPRO-852 added logic to handle articleType value little better (when it ...

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/article.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/article.ftl
@@ -9,8 +9,8 @@
 <#assign depth = 0 />
 
 <#include "../common/head.ftl" />
-
 <#include "../common/journalStyle.ftl" />
+<#include "../common/article/articleType.ftl" />
 
 <#include "analyticsArticleJS.ftl" />
 

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -1,6 +1,7 @@
 <div id="container-main">
 
 <#include "../common/header/header.ftl" />
+<#include "../common/article/articleType.ftl" />
 
   <div id="article-content" class="content" data-article-id="0059893">
     <article class="article-item">
@@ -9,7 +10,6 @@
     <a class="save-article circular coloration-text-color" data-list-type="individual">x</a>
     -->
 
-      <#assign articleTypeHeading = (article.articleType??)?string(article.articleType.heading, '') />
       <h5 class="item-title lead-in">${articleTypeHeading}</h5>
 
       <h2 class="article-title">${article.title}</h2>

--- a/src/main/webapp/WEB-INF/themes/root/ftl/common/article/articleType.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/common/article/articleType.ftl
@@ -1,0 +1,11 @@
+<#if (article.articleType?? && article.articleType.heading?has_content) >
+  <#assign articleTypeHeading = article.articleType.heading />
+<#else>
+  <#assign articleTypeHeading = "unclassified" />
+</#if>
+
+<#if (article.articleType?? && article.articleType.code?has_content) >
+  <#assign partialArticleTypeLink = "#" + article.articleType.code />
+<#else>
+  <#assign partialArticleTypeLink = '' />
+</#if>


### PR DESCRIPTION
...is not provided correctly)

AC
If we use an article type we don't recognize, we display "unclassified" for mobile and desktop.

Display the article type description when a user hover overs the article type text and the link in the description is correct.

If the article type is one of the following, we do not display the subject area on the RHS of the article page
correction, retraction and expression of concern 

NOTE: The following item used to be requirement but functionality is broken in ambra. We decided that it was too crazy to have the authors tab appear and disappear depending on which webapp is serving up the article page, we decided to always display the author tab in wombat as well. This will be addressed in DPRO-855.
If the article type is one of the following, we do not display the "Authors" tab on the article page.
correction, retraction and expression of concern
