### PR TITLE
DPRO-887: Upgrade Rhombat dependency to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <org.springsecurity-version>3.2.2.RELEASE</org.springsecurity-version>
     <org.aspectj-version>1.6.10</org.aspectj-version>
     <org.slf4j-version>1.6.6</org.slf4j-version>
-    <rhombat.version>1.0.1</rhombat.version>
+    <rhombat.version>1.0.2</rhombat.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     <buildDate>${maven.build.timestamp}</buildDate>


### PR DESCRIPTION
This is related to DPRO-887 bug.  https://github.com/PLOS/rhombat/pull/1
