### PR TITLE
Fixing the citation meta tag that was missing author data

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
@@ -11,34 +11,34 @@
   </#list>
 </#if>
 
-<meta name="citation_title" content="${article.title?replace('<.+?>',' ','r')?html}"/>
-<meta itemprop="name" content="${article.title?replace('<.+?>',' ','r')?html}"/>
+<meta name="citation_title" content="${article.title?replace('<.+?>',' ','r')?html}" />
+<meta itemprop="name" content="${article.title?replace('<.+?>',' ','r')?html}" />
 
 <#if article.date??>
-<meta name="citation_date" content="${article.date}"/>
+<meta name="citation_date" content="${article.date}" />
 </#if>
 
 <#if article.citedArticles??>
   <#list article.citedArticles as citedArticle>
-  <meta name="citation_reference"
-        content="
-        <#if citedArticle.title??>citation_title=${citedArticle.title};</#if>
-        <#if citedArticle.authors??>citation_author=<#list citedArticle.authors as author>${author.fullName};</#list></#if>
-        <#if citedArticle.journal??>citation_journal_title=${citedArticle.journal};</#if>
-        <#if citedArticle.volume??>citation_volume=${citedArticle.volume};</#if>
-        <#if citedArticle.volumeNumber??>citation_number=${citedArticle.volumeNumber};</#if>
-        <#if citedArticle.pages??>citation_pages=${citedArticle.pages};</#if>
-        <#if citedArticle.created??>citation_date=${citedArticle.created};</#if>" />
+  <meta name="citation_reference" content="
+    <#if citedArticle.title??>citation_title=${citedArticle.title};</#if><#if citedArticle.authors?has_content>
+    citation_author=<#list citedArticle.authors as author>${author.fullName};</#list></#if><#if citedArticle.editors?has_content>
+    citation_editors=<#list citedArticle.editors as editor>${editor.fullName};</#list></#if><#if citedArticle.journal??>
+    citation_journal_title=${citedArticle.journal};</#if><#if citedArticle.volume??>
+    citation_volume=${citedArticle.volume};</#if><#if citedArticle.volumeNumber??>
+    citation_number=${citedArticle.volumeNumber};</#if><#if citedArticle.pages??>
+    citation_pages=${citedArticle.pages};</#if><#if citedArticle.year??>
+    citation_date=${citedArticle.year?string.computer};</#if>" />
   </#list>
 </#if>
 
 <#if article.publishedJournal??>
 <meta name="citation_journal_title" content="${article.publishedJournal}" />
 </#if>
-<meta name="citation_firstpage" content="${article.eLocationId!}"/>
-<meta name="citation_issue" content="${article.issue}"/>
-<meta name="citation_volume" content="${article.volume}"/>
-<meta name="citation_issn" content="${article.eIssn}"/>
+<meta name="citation_firstpage" content="${article.eLocationId!}" />
+<meta name="citation_issue" content="${article.issue}" />
+<meta name="citation_volume" content="${article.volume}" />
+<meta name="citation_issn" content="${article.eIssn}" />
 
 <#if journalAbbrev??>
 <meta name="citation_journal_abbrev" content="${journalAbbrev}" />
@@ -52,16 +52,16 @@
 
 <#if article.description??>
   <#if twitterUsername?has_content>
-    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="${twitterUsername}"/>
   </#if>
   <meta property="og:type" content="article" />
   <#if pubUrlPrefix?has_content>
-    <meta property="og:url" content="${pubUrlPrefix}article?id=${articleDoi}"/>
+    <meta property="og:url" content="${pubUrlPrefix}article?id=${articleDoi}" />
   </#if>
-  <meta property="og:title" content="${article.title?replace('<.+?>',' ','r')?html}"/>
-  <meta property="og:description" content="${article.description?replace('<.+?>',' ','r')?html}"/>
+  <meta property="og:title" content="${article.title?replace('<.+?>',' ','r')?html}" />
+  <meta property="og:description" content="${article.description?replace('<.+?>',' ','r')?html}" />
   <#if (article.strkImgURI?? && (article.strkImgURI?length > 0)) >
-  <meta property="og:image" content="http://dx.plos.org/${article.strkImgURI?replace('info:doi/','')}"/>
+  <meta property="og:image" content="http://dx.plos.org/${article.strkImgURI?replace('info:doi/','')}" />
   </#if>
 </#if>


### PR DESCRIPTION
This branch is a second attempt at addressing the problem with google scholar not indexing our articles because of some missing meta data included in the head of the document. The original branch that was merged incorrectly assumed that all citedArticles have authors, which is not the case. Some articles can have no authors and only editors and vice versa. This code checks if editors or authors exists, then loops through to include their fullNames. It is interesting to note the odd location of the "if" statements on preceding lines. This is an unfortunate requirement to ensure blank lines are not added into the HTML when there are no authors or editors for that particular citation. I love you @johnfesenko .
