### PR TITLE
BAU-3171 MathML has extraneous line wrapping in Wombat.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
@@ -12,5 +12,5 @@ linebreaks: {
 </script>
 
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="http://cdn.mathjax.org/mathjax/2.1-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>


### PR DESCRIPTION
Currently Wombat uses the latest available version of MathJax (v2.5). 

This change restricts the MathJax version to 2.1, which is what's used in Ambra. This resolves the display issues recorded in BAU-3171. 

Please DO NOT DELETE this branch after merging it upon a successful CR.
