### PR TITLE
dev-BAU-2572 update transforms to show 6 authors in citation line, and u...

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -116,9 +116,9 @@
       <p>
         <strong>Citation:&#032;</strong>
         <!-- authors -->
-        <xsl:for-each select="contrib-group/contrib[@contrib-type='author'][position() &lt; 7]">
+        <xsl:for-each select="contrib-group/contrib[@contrib-type='author'][position() &lt; 8]">
           <xsl:choose>
-            <xsl:when test="position() = 6">
+            <xsl:when test="position() = 7">
               <xsl:text>et al. </xsl:text>
             </xsl:when>
             <xsl:otherwise>
@@ -1509,27 +1509,27 @@
   <!-- 1/4/12: nlm contains alt-text (suppressed here, processed within graphic|inline-graphic) -->
 
   <!-- 1/4/12: Ambra modifications -->
-  <xsl:template match="list">
-    <xsl:call-template name="newline1"/>
-    <xsl:choose>
-      <xsl:when test="@list-type='bullet'">
+    <xsl:template match="list">
         <xsl:call-template name="newline1"/>
-        <ul class="bulleted">
-          <xsl:call-template name="newline1"/>
-          <xsl:apply-templates/>
-          <xsl:call-template name="newline1"/>
-        </ul>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:call-template name="newline1"/>
-        <ol class="{@list-type}">
-          <xsl:call-template name="newline1"/>
-          <xsl:apply-templates/>
-          <xsl:call-template name="newline1"/>
-        </ol>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
+        <xsl:choose>
+            <xsl:when test="@list-type='bullet'">
+                <xsl:call-template name="newline1"/>
+                <ul class="bulleted">
+                    <xsl:call-template name="newline1"/>
+                    <xsl:apply-templates/>
+                    <xsl:call-template name="newline1"/>
+                </ul>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="newline1"/>
+                <ol class="{@list-type}">
+                    <xsl:call-template name="newline1"/>
+                    <xsl:apply-templates/>
+                    <xsl:call-template name="newline1"/>
+                </ol>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
 
   <!-- 1/4/12: suppress, we don't use -->
   <xsl:template priority="2" mode="list" match="list[@list-type='simple' or list-item/label]"/>

--- a/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
@@ -103,9 +103,9 @@
         <strong>Citation:</strong>
         <xsl:text> </xsl:text>
         <!-- authors -->
-        <xsl:for-each select="contrib-group/contrib[@contrib-type='author'][position() &lt; 7]">
+        <xsl:for-each select="contrib-group/contrib[@contrib-type='author'][position() &lt; 8]">
           <xsl:choose>
-            <xsl:when test="position() = 6">
+            <xsl:when test="position() = 7">
               <xsl:text>et al. </xsl:text>
             </xsl:when>
             <xsl:otherwise>
@@ -218,6 +218,12 @@
           </xsl:otherwise>
         </xsl:choose>
       </p>
+      <!-- Data Availability -->
+      <xsl:if test="custom-meta-group/custom-meta[@id='data-availability']">
+        <p>
+        <xsl:apply-templates select="custom-meta-group/custom-meta[@id='data-availability']/meta-value" mode="metadata"/>
+        </p>
+      </xsl:if>
       <!-- funding statement -->
       <xsl:if test="funding-group">
         <p>
@@ -310,6 +316,12 @@
   <xsl:template match="permissions" mode="metadata"/>
   <xsl:template match="copyright-statement" mode="metadata"/>
 
+  <!-- 5/20/14: plos modifications -->
+  <xsl:template match="custom-meta-group/custom-meta[@id='data-availability']/meta-value" mode="metadata">
+    <strong>Data Availability: </strong>
+    <xsl:apply-templates />
+  </xsl:template>
+  
   <!-- Ambra modifications -->
   <xsl:template match="license" mode="metadata">
     <xsl:apply-templates mode="metadata"/>


### PR DESCRIPTION
...pdate mobile transform for data availability statement so we can remove transform from plos-themes.

The diffs in the request around line 1512 for the desktop transform are just due to whitespace changes, the code wasn't altered otherwise.

Also, there was the extra mobile transform that was sitting in plos-themes that had the code for the data availabilty statement. I moved that code into the mobile transform in this repo, and deleted the transform in plos-themes (on the dev-BAU-2572 branch there). We'll want to merge/deploy the BAU-2572 branch there and here at the same time, so the data availability doesn't disappear for a random amount of time on the mobile sites.
