### PR TITLE
dev-BAU-3622 Google Scholar Meta tag fixes

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
@@ -31,7 +31,7 @@
 <#if article.publisherName??>
 <meta name="citation_publisher" content="${article.publisherName}" />
 </#if>
-<meta name="citation_pdf_url" content="${pubUrlPrefix}article/asset?id=${article.doi}.PDF">
+<meta name="citation_pdf_url" content="${pubUrlPrefix}article/asset?id=${article.articlePdf.file}">
 
 <#--//crossmark identifier-->
 <meta name="dc.identifier" content="${articleDoi}" />

--- a/src/main/webapp/WEB-INF/themes/root/ftl/article/alterJournalTitle.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/article/alterJournalTitle.ftl
@@ -1,4 +1,6 @@
 <#function alterJournalTitle journalTitle>
-<#--Put a comment-->
+    <#--This is a hook that individual journals can use to implement their own alteration to journal titles and prevent
+     the pollution of PLOS specific code in Wombat. See plos_themes/code/general/Plos/ftl/article/alterJournalTitle.ftl
+     for an example implementation.-->
     <#return journalTitle />
 </#function>


### PR DESCRIPTION
This is the super duper followup to the Google Scholar meta tag fixes in Wombat. It addresses their concerns regarding missing and empty tags outline below:
1. Add the citation_journal_title to the meta data.
   - This is the journal title for the article itself.
2. Convert the citation_date timestamp to a human readable format.
   - The citation date was converted from a computer timestamp to a human readable format.
3. Break out citation_authors into their own separate tags.
   - I modified the code to put each citation author into their own entry. 
4. Address empty citation tags.
   - In the cases where the citation data in the database is empty, no citation tag will be included, rather than spit out an empty tag. In the future, we should come up with a way to take the entirety of a malformed/insufficiently marked up citation and add it into the database in it's entirety during ingest through Rhino.
5. Add in citation tags for citation_pdf_url and journal abbrev

Note: I also re-arranged the citation meta data that is specific for the URL to appear all together above the citation_references. 

Please don't delete this branch immediately after merging so it can be pulled by QA to be tested.
