### PR TITLE
DPRO-1077: prevent pone.0116586 article page from throwing a 500.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -863,7 +863,6 @@
             <xsl:if test="$cit[@publication-type='journal']">
               <!-- create reference links -->
               <!-- if citedArticles parameter has not been set, fail gracefully and use XML-based data for links -->
-              <xsl:variable name="pubYear" select="$cit/year[1]"/>
               <!-- use author and title preferentially from database, then XML -->
               <xsl:variable name="author">
               <xsl:choose>
@@ -938,6 +937,7 @@
                     <xsl:element name="a">
                       <xsl:attribute name="href">
                         <!-- build link and use + for spaces for consistency with Ambra -->
+                        <xsl:variable name="pubYear" select="($cit/year)[1]"/>
                         <xsl:value-of select="replace(concat('http://scholar.google.com/scholar_lookup?title=',
                         $title,'&amp;author=', $author, '&amp;publication_year=', $pubYear),'%20','+')"/>
                       </xsl:attribute>


### PR DESCRIPTION
There is one citation in this article's XML that has two publication
dates.  I added some parentheses to fix on order-of-operations problem
converting a (potential) sequence to a scalar, to fix the article
transform.
