### PR TITLE
DPRO-1207: fix login for journal sites.

### DIFF
--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -42,6 +42,7 @@
 
   <beans:bean id="casFilter" class="org.springframework.security.cas.web.CasAuthenticationFilter">
     <beans:property name="authenticationManager" ref="authenticationManager"/>
+    <beans:property name="filterProcessesUrl" value="/j_spring_cas_security_check" />
   </beans:bean>
 
   <beans:bean id="casEntryPoint" class="org.springframework.security.cas.web.CasAuthenticationEntryPoint">


### PR DESCRIPTION
Spring security 4.0 changed the default URL path where CAS redirects
after successful login.
