### PR TITLE
IO-3696 Fix bug that was supressing text marked <sans-serif> in XML.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -2533,7 +2533,6 @@
   <!-- 1/4/12: suppress, we don't use -->
   <xsl:template match="price"/>
   <xsl:template match="roman"/>
-  <xsl:template match="sans-serif"/>
 
   <!-- 1/4/12: Ambra modifications -->
   <xsl:template match="sc">

--- a/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
@@ -2349,7 +2349,6 @@
   <!-- suppress, we don't use -->
   <xsl:template match="price"/>
   <xsl:template match="roman"/>
-  <xsl:template match="sans-serif"/>
 
   <!-- Ambra modifications -->
   <xsl:template match="sc">

--- a/src/main/webapp/WEB-INF/themes/root/xform/jpub3-html.xsl
+++ b/src/main/webapp/WEB-INF/themes/root/xform/jpub3-html.xsl
@@ -2699,7 +2699,7 @@
 
 
   <xsl:template match="sans-serif">
-    <span style="font-family: sans-serif; font-size: 80%">
+    <span style="font-family: sans-serif;">
       <xsl:apply-templates/>
     </span>
   </xsl:template>


### PR DESCRIPTION
This was the final decision after deliberating with Tina, Sebastian, and Patrick for dealing with text marked sans-serif. If the author decides they want to differentiate the text, they should use a different set of tags. See IO-3969
for the corresponding conversation and decision.

```
    - Removed the XSL Supression in the desktop and mobile article-transforms
    - Changed the sans-serif styling, the text will appear as the body text
```
