### PR TITLE
DPRO-1135: serve search results coming from the ambra advanced search…

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/SearchController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/SearchController.java
@@ -40,9 +40,36 @@ public class SearchController extends WombatController {
   @Autowired
   private SearchService searchService;
 
+  /**
+   * Performs a search.
+   *
+   * @param model information to be sent to the template
+   * @param site the current site
+   * @param query "simple search" query.  This word or phrase will be searched against all
+   *     solr fields.
+   * @param unformattedQuery "advanced search" query.  This may be a boolean combination of any
+   *     predicates that query any of the solr fields.  This is the boolean expression that can
+   *     be built on the advanced search page.  If present, query will be ignored.
+   * @param subject if present, a subject search will be performed on this subject, and query and
+   *     unformattedQuery will be ignored.
+   * @param author if present, an author search will be performed on this author, and query and
+   *     unformattedQuery will be ignored.
+   * @param page results page we are requesting (1-based).  If absent, the first page of results
+   *     will be returned.
+   * @param sortOrderParam specifies the sort order of results.  If absent, the sort order will
+   *     default to relevance.
+   * @param dateRangeParam specifies the publication date range for the results.  If absent, results
+   *     from all time will be returned.
+   * @param resultsPerPage maximum number of results to return (for the given results page).
+   * @param journals list of journal keys in which to search.  If absent, the search will only
+   *     be over the current site.
+   * @return path to the search results freemarker template
+   * @throws IOException
+   */
   @RequestMapping(value = {"/search", "/{site}/search"})
   public String search(Model model, @SiteParam Site site,
                        @RequestParam(value = "q", required = false) String query,
+                       @RequestParam(value = "unformattedQuery", required = false) String unformattedQuery,
                        @RequestParam(value = "subject", required = false) String subject,
                        @RequestParam(value = "author", required = false) String author,
                        @RequestParam(value = "page", required = false) Integer page,
@@ -87,7 +114,9 @@ public class SearchController extends WombatController {
     model.addAttribute("selectedResultsPerPage", resultsPerPage);
 
     Map<?, ?> searchResults;
-    if (!Strings.isNullOrEmpty(subject)) {
+    if (!Strings.isNullOrEmpty(unformattedQuery)) {
+      searchResults = searchService.advancedSearch(unformattedQuery, journals, start, resultsPerPage, sortOrder);
+    } else if (!Strings.isNullOrEmpty(subject)) {
       searchResults = searchService.subjectSearch(subject, journals, start, resultsPerPage, sortOrder, dateRange);
     } else if (!Strings.isNullOrEmpty(author)) {
       searchResults = searchService.authorSearch(author, journals, start, resultsPerPage, sortOrder, dateRange);

--- a/src/main/java/org/ambraproject/wombat/service/remote/SearchService.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/SearchService.java
@@ -58,6 +58,21 @@ public interface SearchService {
                                 SearchCriterion dateRange) throws IOException;
 
   /**
+   * Performs an "advanced search": the query parameter will be directly parsed by solr.
+   *
+   * @param query specifies the solr fields and the values we are searching for; may be a boolean
+   *     combination of these.  Example: "(abstract:gene) AND author:smith".
+   * @param journalKeys list of the journals in which to search
+   * @param start starting result, zero-based.  0 will start at the first result.
+   * @param rows max number of results to return
+   * @param sortOrder specifies the desired ordering for results
+   * @return deserialized JSON returned by the search server
+   * @throws IOException
+   */
+  public Map<?, ?> advancedSearch(String query, List<String> journalKeys, int start, int rows,
+      SearchCriterion sortOrder) throws IOException;
+
+  /**
    * Performs a search by the subject fields.
    *
    * @param subject   taxonomy term the search will be restricted to

--- a/src/main/java/org/ambraproject/wombat/service/remote/SolrSearchService.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/SolrSearchService.java
@@ -163,6 +163,14 @@ public class SolrSearchService implements SearchService {
     return executeQuery(params);
   }
 
+  @Override
+  public Map<?, ?> advancedSearch(String query, List<String> journalKeys, int start, int rows,
+      SearchCriterion sortOrder) throws IOException {
+    List<NameValuePair> params = buildCommonParams(journalKeys, start, rows, sortOrder, null, false);
+    params.add(new BasicNameValuePair("q", query));
+    return executeQuery(params);
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -234,9 +242,11 @@ public class SolrSearchService implements SearchService {
       sortOrderStr += ",id desc";
     }
     params.add(new BasicNameValuePair("sort", sortOrderStr));
-    String dateRangeStr = dateRange.getValue();
-    if (!Strings.isNullOrEmpty(dateRangeStr)) {
-      params.add(new BasicNameValuePair("fq", "publication_date:" + dateRangeStr));
+    if (dateRange != null) {
+      String dateRangeStr = dateRange.getValue();
+      if (!Strings.isNullOrEmpty(dateRangeStr)) {
+        params.add(new BasicNameValuePair("fq", "publication_date:" + dateRangeStr));
+      }
     }
     List<String> crossPublishedJournals = new ArrayList<>();
     for (String journalKey : journalKeys) {

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/search/searchResults.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/search/searchResults.ftl
@@ -19,6 +19,14 @@
   <#assign journalName = v />
 </@themeConfig>
 
+<#if RequestParameters.q??>
+  <#assign query = RequestParameters.q?html />
+  <#assign advancedSearch = false />
+<#else>
+  <#assign query = RequestParameters.unformattedQuery?html />
+  <#assign advancedSearch = true />
+</#if>
+
 <body class="static ${journalStyle}">
 
   <#assign headerOmitMain = true />
@@ -31,10 +39,10 @@
           <fieldset>
             <legend>Search</legend>
             <label for="controlBarSearch">Search</label>
-            <input id="controlBarSearch" type="text" name="q" value="${RequestParameters.q?html}" required />
+            <input id="controlBarSearch" type="text" name="${advancedSearch?string('unformattedQuery', 'q')}" value="${query}" required />
             <button type="submit"><span class="search-icon"></span></button>
           </fieldset>
-          <a class="search-results-button-hover-branded" href="${legacyUrlPrefix}search/advanced?filterJournals=${journalKey}&query=${RequestParameters.q?html}&noSearchFlag=set">advanced</a>
+          <a class="search-results-button-hover-branded" href="${legacyUrlPrefix}search/advanced?filterJournals=${journalKey}&query=${query}&noSearchFlag=set">advanced</a>
         </div>
 
         <div class="search-results-controls-second-row">
@@ -62,11 +70,11 @@
       <#if searchResults.numFound == 0>
         <div class="search-results-none-found">
           <p>You searched for articles that have all of the following:</p>
-          <p>Search Term: "<span>${RequestParameters.q?html}</span>"</p>
+          <p>Search Term: "<span>${query}</span>"</p>
           <p>Journal: "<span>${journalName}</span>"</p>
           <p>
             There were no results; please
-            <a href="${legacyUrlPrefix}search/advanced?filterJournals=${journalKey}&query=${RequestParameters.q?html}&noSearchFlag=set">refine your search</a>
+            <a href="${legacyUrlPrefix}search/advanced?filterJournals=${journalKey}&query=${query}&noSearchFlag=set">refine your search</a>
             and try again.</p>
         </div>
       <#else>
@@ -76,7 +84,7 @@
         <#else>
           results
         </#if>
-        for <span>${RequestParameters.q?html}</span>
+        for <span>${query}</span>
       </div>
       <dl class="search-results-list">
         <#list searchResults.docs as doc>

--- a/src/test/java/org/ambraproject/wombat/service/remote/SearchServiceTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/remote/SearchServiceTest.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = TestSpringConfiguration.class)
 public class SearchServiceTest extends AbstractTestNGSpringContextTests {
@@ -54,6 +55,18 @@ public class SearchServiceTest extends AbstractTestNGSpringContextTests {
     assertSingle(actualMap.get("start"), "20");
     assertSingle(actualMap.get("sort"), "score desc,publication_date desc,id desc");
     assertJournals(actualMap.get("fq"), "foo", "bar", "blaz");
+
+    // null date range
+    actual = searchService.buildCommonParams(Collections.singletonList("foo"), 0, 15,
+        SolrSearchService.SolrSortOrder.RELEVANCE, null, false);
+    actualMap = convertToMap(actual);
+    assertCommonParams(actualMap, 3);
+    Set<String> fq = actualMap.get("fq");
+    for (String s : fq) {
+      if (s.startsWith("publication_date:")) {
+        fail(s);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
… form.

I tested this by adding code to plos-templates that performs a client-side redirect from my ambra instance to my wombat instance for any "advanced" search results.  In production, we'll accomplish this with apache rewrites.  I checked this into the plos-templates branch dev-wombat-advanced-search-test.  Here is the gist:

```
<script type="text/javascript">
  if (window.location.pathname.startsWith('/search/advanced')) {
    var newUrl = 'http://jcallaway.plos.org:8080/wombat/DesktopPlosOne/search' + window.location.search;
    console.log('Redirecting to wombat: ' + newUrl);
    window.location.href = newUrl;
  }
</script>
```
