### PR TITLE
DPRO-1388: ignore the timezone coming from solr for pub dates, and us…

### DIFF
--- a/src/main/java/org/ambraproject/wombat/freemarker/Iso8601DateDirective.java
+++ b/src/main/java/org/ambraproject/wombat/freemarker/Iso8601DateDirective.java
@@ -24,6 +24,12 @@ import java.util.Map;
 
 /**
  * FreeMarker custom directive that parses a ISO 8601 date representation and formats it appropriately.
+ *
+ * This directive accepts the following parameters:
+ *   - date (required): a date string in the ISO 8601 format
+ *   - format (required): format string to use for output
+ *   - interpretDateAsLocalTime: if true, the timezone in the date string will be ignored, and the
+ *     timezone of the local server will be used instead (this is to work around DPRO-1388)
  */
 public class Iso8601DateDirective implements TemplateDirectiveModel {
 
@@ -41,7 +47,10 @@ public class Iso8601DateDirective implements TemplateDirectiveModel {
       throw new TemplateModelException("format parameter is required");
     }
     String format = params.get("format").toString();
-    String formattedDate = CalendarUtil.formatIso8601Date(jsonDate, format);
+    Object interpretDateAsLocalTimeParam = params.get("interpretDateAsLocalTime");
+    boolean interpretDateAsLocalTime = interpretDateAsLocalTimeParam != null &&
+        !Boolean.FALSE.toString().equalsIgnoreCase(interpretDateAsLocalTimeParam.toString());
+    String formattedDate = CalendarUtil.formatIso8601Date(jsonDate, format, interpretDateAsLocalTime);
     environment.getOut().write(formattedDate);
   }
 }

--- a/src/main/java/org/ambraproject/wombat/util/CalendarUtil.java
+++ b/src/main/java/org/ambraproject/wombat/util/CalendarUtil.java
@@ -3,6 +3,7 @@ package org.ambraproject.wombat.util;
 import javax.xml.bind.DatatypeConverter;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.TimeZone;
 
 public class CalendarUtil {
@@ -10,10 +11,24 @@ public class CalendarUtil {
     throw new AssertionError("Not instantiable");
   }
 
-  public static String formatIso8601Date(String date, String format) {
+  /**
+   * Formats a date string expressed in the ISO 8601 format.
+   *
+   * @param date ISO 8601 formatted date string
+   * @param format format string to output
+   * @param interpretDateAsLocalTime if true, the timezone in the date string input will be ignored,
+   *     and the local server's timezone used instead.  This is a dangerous hack, but is necessary
+   *     to work around a current problem in our solr indexing where publication dates are expressed
+   *     as UTC, when they should be in local time.
+   * @return
+   */
+  public static String formatIso8601Date(String date, String format, boolean interpretDateAsLocalTime) {
     Calendar calendar = DatatypeConverter.parseDateTime(date);
-    calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-    return new SimpleDateFormat(format).format(calendar.getTime());
+    if (interpretDateAsLocalTime) {
+      calendar.setTimeZone(TimeZone.getDefault());
+    }  // Else calendar will be set with tz in the ISO-8601 date string, which is usually UTC
+    Date d = calendar.getTime();
+    return new SimpleDateFormat(format).format(d);
   }
 
 }

--- a/src/main/java/org/ambraproject/wombat/util/Citations.java
+++ b/src/main/java/org/ambraproject/wombat/util/Citations.java
@@ -61,7 +61,7 @@ public class Citations {
   private static final Joiner COMMA_JOINER = Joiner.on(", ");
 
   private static String extractYear(String date) {
-    return CalendarUtil.formatIso8601Date(date, "yyyy");
+    return CalendarUtil.formatIso8601Date(date, "yyyy", false);
   }
 
   /*

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/search/searchResults.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/search/searchResults.ftl
@@ -149,7 +149,7 @@
               <span id="article-result-${doc_index}-type">${doc.article_type}</span> |
             </#if>
               <span id="article-result-${doc_index}-date">
-                published <@formatJsonDate date="${doc.publication_date}" format="dd MMM yyyy" /> |
+                published <@formatJsonDate date="${doc.publication_date}" format="dd MMM yyyy" interpretDateAsLocalTime="true" /> |
               </span>
             <#if doc.cross_published_journal_name??>
               <span id="article-result-${doc_index}-journal-name">

--- a/src/test/java/org/ambraproject/wombat/util/CalendarUtilTest.java
+++ b/src/test/java/org/ambraproject/wombat/util/CalendarUtilTest.java
@@ -1,0 +1,18 @@
+package org.ambraproject.wombat.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class CalendarUtilTest {
+
+  @Test
+  public void testFormatIso8601Date() {
+    assertEquals(CalendarUtil.formatIso8601Date("2015-01-13T00:00:00Z", "yyyy-MM-dd", false), "2015-01-12");
+    assertEquals(CalendarUtil.formatIso8601Date("2015-01-13T00:00:00Z", "yyyy-MM-dd", true), "2015-01-13");
+
+    // Try a day when daylight savings time was in effect.
+    assertEquals(CalendarUtil.formatIso8601Date("2015-08-07T00:00:00Z", "yyyy-MM-dd", false), "2015-08-06");
+    assertEquals(CalendarUtil.formatIso8601Date("2015-08-07T00:00:00Z", "yyyy-MM-dd", true), "2015-08-07");
+  }
+}


### PR DESCRIPTION
…e local time instead.

See DPRO-1388 for discussion.  This is a hack necessary since publication
dates in solr are always midnight UTC, while those in the ambra DB (and
displayed on the article page) are always midnight in the server's local
timezone (US/Los Angeles).
