### PR TITLE
DPRO-1478: Revert to old aside link for collections

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/asideCollections.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/asideCollections.ftl
@@ -1,12 +1,13 @@
+
 <div class="aside-container">
-  <h3>Included in the Following <#if article.collections?size == 1>Collection<#else>Collections</#if></h3>
+  <h3>Included in the Following Collection</h3>
   <ul id="collectionList">
-  <#list article.collections as articleCollection>
+  <#list collectionIssues?keys as issueDoi>
     <li>
-      <#assign collectionLinkPath = "collection/${articleCollection.slug}" /><#-- Placeholder. TODO: Build correct link -->
-      <a href="<@siteLink path=collectionLinkPath journalKey=articleCollection.journalKey/>">
-      ${articleCollection.title}
-      </a>
+     <#-- TODO: Implement issue-browsing and point the link to it (this placeholder is currently a 404) -->
+     <a href="<@siteLink path="issue?id=" + issueDoi
+                         journalKey=collectionIssues[issueDoi]["parentJournal"]["journalKey"]/>">
+        ${collectionIssues[issueDoi]["displayName"]}</a>
     </li>
   </#list>
   </ul>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/sidebar.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/sidebar.ftl
@@ -9,7 +9,7 @@
 
 <#include "relatedArticles.ftl" />
 
-<#if article.collections?size gt 0>
+<#if collectionIssues?keys?size gt 0>
   <#include "asideCollections.ftl" />
 </#if>
 


### PR DESCRIPTION
This allows the page to work without depending on the 'collections' field
of article metadata as served by Rhino. When Rhino's collections
persistence feature is stable, we should once again use it.

Revert "DPRO-1103: Wire collections page to new article metadata"
This reverts commit 4ff1ad3f63880afc34dc930304a92021e6ccc552.
