### PR TITLE
DPRO-1628: Fix ThemeTreeTest.testInheritPropertyFromRoot

### DIFF
--- a/src/test/java/org/ambraproject/wombat/config/TestSpringConfiguration.java
+++ b/src/test/java/org/ambraproject/wombat/config/TestSpringConfiguration.java
@@ -52,8 +52,6 @@ public class TestSpringConfiguration {
     themes.add(theme1);
     TestClasspathTheme theme2 = new TestClasspathTheme("site2", Collections.singletonList(rootTheme));
     themes.add(theme2);
-    TestClasspathTheme collectionTheme = new TestClasspathTheme("collectionSite", Collections.singletonList(rootTheme));
-    themes.add(collectionTheme);
     return runtimeConfiguration.getThemes(themes, rootTheme);
   }
 

--- a/src/test/java/org/ambraproject/wombat/config/theme/ThemeTreeTest.java
+++ b/src/test/java/org/ambraproject/wombat/config/theme/ThemeTreeTest.java
@@ -13,11 +13,9 @@ import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = TestSpringConfiguration.class)
 public class ThemeTreeTest extends AbstractTestNGSpringContextTests {
@@ -102,8 +100,17 @@ public class ThemeTreeTest extends AbstractTestNGSpringContextTests {
   @Test
   public void testInheritPropertyFromRoot() throws IOException {
     Site site = MockSiteUtil.getByUniqueJournalKey(siteSet, "journal1Key");
-    Object inheritedValue = site.getTheme().getConfigMap("journal").get("isCollection");
-    assertNotNull(inheritedValue);
-    assertFalse((boolean) inheritedValue);
+    Map<String, Object> journal = site.getTheme().getConfigMap("homepage");
+    Object inheritedValue = journal.get("defaultSelection");
+    assertEquals(inheritedValue, "recent"); // expected to match src/main/webapp/WEB-INF/themes/root/config/homepage.yaml
   }
+
+  @Test
+  public void testCanOverridePropertyFromRoot() throws IOException {
+    Site site = MockSiteUtil.getByUniqueJournalKey(siteSet, "journal2Key");
+    Map<String, Object> journal = site.getTheme().getConfigMap("homepage");
+    Object inheritedValue = journal.get("defaultSelection");
+    assertEquals(inheritedValue, "popular"); // expected to match src/test/resources/test_themes/site2/config/homepage.json
+  }
+
 }

--- a/src/test/resources/test_themes/collectionSite/config/journal.json
+++ b/src/test/resources/test_themes/collectionSite/config/journal.json
@@ -1,5 +1,0 @@
-{
-  "journalKey": "collectionJournalKey",
-  "journalName": "Collection Journal",
-  "isCollection": true
-}

--- a/src/test/resources/test_themes/site2/config/homepage.json
+++ b/src/test/resources/test_themes/site2/config/homepage.json
@@ -1,0 +1,9 @@
+{
+  "sections": [
+    {
+      "name": "popular",
+      "resultCount": 5
+    }
+  ],
+  "defaultSelection": "popular"
+}


### PR DESCRIPTION
Removed "collection" test theme, since the root config no longer recognizes
being a collection as a configurable property.

Replaced it with values from the homepage config. Now tests that properties
can be inherited and overridden.
