### PR TITLE
DPRO-1653: Prevent broken pagination macro on curated lists

### DIFF
--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/home/home.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/home/home.ftl
@@ -47,7 +47,7 @@
           </ul>
         </section>
 
-        <#if selectedSection != "in_the_news">
+        <#if selectedSection == "recent" || selectedSection == "popular">
           <#assign numPages = (articles?size / resultsPerPage)?ceiling />
           <#assign currentPage = (RequestParameters.page!1)?number />
           <#assign path = "" />


### PR DESCRIPTION
Now that 'selectedSection' can be the key of any curated article list, we need to apply Solr-backed pagination only on the non-curated section types.

This is a short-term fix for the crash. It is not necessarily the complete, desired fix for the DPRO-1653 bug.
