### PR TITLE
DPRO-1692: Fix unit test config imports

### DIFF
--- a/src/test/java/org/ambraproject/wombat/controller/StaticResourceControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/StaticResourceControllerTest.java
@@ -13,6 +13,7 @@ import org.ambraproject.wombat.config.theme.Theme;
 import org.ambraproject.wombat.service.AssetService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.testng.annotations.BeforeMethod;
@@ -129,7 +130,8 @@ public class StaticResourceControllerTest extends ControllerTest {
 
   @Configuration
   @EnableWebMvc
-  static class TestConfig extends WombatControllerTestConfig {
+  @Import(WombatControllerTestConfig.class)
+  static class TestConfig {
 
     @Bean
     public StaticResourceController staticResourceController() {
@@ -141,9 +143,8 @@ public class StaticResourceControllerTest extends ControllerTest {
       return assetService;
     }
 
-    @Override
     @Bean
-    public SiteSet siteSetDependency() {
+    public SiteSet siteSet() {
       SiteRequestScheme mockRequestScheme = mock(SiteRequestScheme.class);
       when(mockRequestScheme.isForSite(any(HttpServletRequest.class))).thenReturn(true);
 

--- a/src/test/java/org/ambraproject/wombat/controller/WombatControllerTestConfig.java
+++ b/src/test/java/org/ambraproject/wombat/controller/WombatControllerTestConfig.java
@@ -11,6 +11,7 @@ import freemarker.template.TemplateDirectiveBody;
 import freemarker.template.TemplateDirectiveModel;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
+import org.ambraproject.wombat.config.TestSpringConfiguration;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.config.site.SiteResolver;
 import org.ambraproject.wombat.config.site.SiteSet;
@@ -19,6 +20,7 @@ import org.ambraproject.wombat.freemarker.Iso8601DateDirective;
 import org.ambraproject.wombat.freemarker.RandomIntegerDirective;
 import org.ambraproject.wombat.freemarker.ReplaceParametersDirective;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -40,6 +42,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Import(TestSpringConfiguration.class)
 public class WombatControllerTestConfig extends WebMvcConfigurerAdapter {
 
   private static SiteResolver resolver = null;


### PR DESCRIPTION
Resolves a bug in which StaticResourceControllerTest.TestConfig was not
able to import the test environment's RuntimeConfiguration bean. Changing
the "siteSetDependency" bean name to "siteSet" was significant because it
was preventing the actual siteSet from being overridden correctly.
