### PR TITLE
DPRO-1733: turned off CSRF protection is spring security

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/SpringSecurityConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/SpringSecurityConfiguration.java
@@ -168,6 +168,7 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .addFilterBefore(singleSignOutFilter(), CasAuthenticationFilter.class)
             .authorizeRequests().antMatchers(AUTH_INTERCEPT_PATTERN).fullyAuthenticated();
     http.exceptionHandling().authenticationEntryPoint(casAuthenticationEntryPoint());
+    http.csrf().disable();
   }
 
   @Override


### PR DESCRIPTION
Temporary measure while we investigate the need for this protection in DRPO-1735
