### PR TITLE
DPRO-1774 - removed metrics.sccs from screen.scss

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/sass/screen.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/screen.scss
@@ -9,4 +9,3 @@
 @import "pages/error";
 @import "pages/article";
 @import "pages/article-body";
-@import "pages/metrics-tab";


### PR DESCRIPTION
I should have caught this in the code review. 
