### PR TITLE
DPRO-1942: Fix display bug with whitespace

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
@@ -28,12 +28,8 @@
 
       <h2>Reader Comments</h2>
 
-      <p class="post_comment">
-        <a href="<@siteLink handlerName="articleCommentPost" queryParameters={"id": article.doi} />">
-          Post a new comment
-        </a>
-        on this article
-      </p>
+    <#include "postNewCommentLink.ftl" />
+    <@postNewCommentLink article.doi />
 
       <div id="respond_prototype" class="reply subresponse cf" style="display: none">
         <h4>Post Your Discussion Comment</h4>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comments.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comments.ftl
@@ -29,11 +29,8 @@
 
       <h2>Reader Comments (${articleComments?size})</h2>
 
-      <p class="post_comment">
-        <a href="<@siteLink handlerName="articleCommentPost" queryParameters={"id": article.doi} />">
-          Post a new comment</a>
-        on this article
-      </p>
+    <#include "postNewCommentLink.ftl" />
+    <@postNewCommentLink article.doi />
 
       <ul id="threads">
       <#list articleComments?sort_by("mostRecentActivity")?reverse as comment>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/postNewCommentLink.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/postNewCommentLink.ftl
@@ -1,0 +1,7 @@
+<#macro postNewCommentLink articleDoi>
+<p class="post_comment">
+  <a href="<@siteLink handlerName="articleCommentPost" queryParameters={"id": articleDoi} />">
+    Post a new comment</a>
+  on this article
+</p>
+</#macro>


### PR DESCRIPTION
The following space should not be part of the link. Extracted redundant
text to a macro to prevent such inconsistencies.
