### PR TITLE
DPRO-1978: Have newComment.ftl wire CI buttons in JavaScript

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/commentSubmissionJs.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/commentSubmissionJs.ftl
@@ -25,6 +25,11 @@
         listThreadURL: "${url?js_string}"
       </@siteLink>
       };
+
+    <#-- Applies only on the root new-comment page.
+         Others invoke wireCompetingInterestRadioButtons dynamically and won't have .startDiscussion
+      -->
+      comments.wireCompetingInterestRadioButtons($('.startDiscussion'));
     };
   }(jQuery));
 </script>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/newComment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/newComment.ftl
@@ -25,7 +25,7 @@
   <#include "../tabs.ftl" />
   <@displayTabList 'comments' />
 
-    <div id="thread">
+    <div id="thread" class="startDiscussion">
       <h2>Start a Discussion</h2>
 
       <div class="reply cf form-default" id="respond">


### PR DESCRIPTION
Fixes a bug where the behavior of radio buttons for competing interests
worked in the thread view but not in the root form for new comments.
