### PR TITLE
DPRO-1935: Kludge formatting on GMT time zone

### DIFF
--- a/src/main/java/org/ambraproject/wombat/util/CalendarUtil.java
+++ b/src/main/java/org/ambraproject/wombat/util/CalendarUtil.java
@@ -7,9 +7,12 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class CalendarUtil {
+
   private CalendarUtil() {
     throw new AssertionError("Not instantiable");
   }
+
+  private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
   /**
    * Formats a date string expressed in the ISO 8601 format.
@@ -27,10 +30,15 @@ public class CalendarUtil {
     if (interpretDateAsLocalTime) {
       calendar.setTimeZone(TimeZone.getDefault());
     }  // Else calendar will be set with tz in the ISO-8601 date string, which is usually UTC
-    Date d = calendar.getTime();
+
+    TimeZone timeZone = calendar.getTimeZone();
+    if ("GMT+00:00".equals(timeZone.getID())) {
+      timeZone = GMT; // kludge for formatting (remove the "+00:00" offset)
+    }
+
     SimpleDateFormat formatObj = new SimpleDateFormat(format);
-    formatObj.setTimeZone(calendar.getTimeZone());
-    return formatObj.format(d);
+    formatObj.setTimeZone(timeZone);
+    return formatObj.format(calendar.getTime());
   }
 
 }


### PR DESCRIPTION
The time zone from the calendar object produced by the `DatatypeConverter.parseDateTime` library method stubbornly wanted to be formatted as `"GMT+00:00"`, which is different from the time zone object produced by `TimeZone.getTimeZone("GMT")`. I don't know why.

This is a very ugly kludge. I hate time zones.
