### PR TITLE
DPRO-2026: Ensure user is directed back to comment page after logging in

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
@@ -99,6 +99,7 @@
 
       <div id="responses">
 
+      <#include "../../macro/userSession.ftl" />
       <#include "userInfoLink.ftl" />
 
       <#assign indentationWidth = 30 />
@@ -170,8 +171,8 @@
           </div>
 
           <div class="toolbar">
-            <#assign userIsLoggedIn = Session["SPRING_SECURITY_CONTEXT"]?exists && Session["SPRING_SECURITY_CONTEXT"].authentication.authenticated />
-            <@siteLink handlerName="userLogin" ; login>
+            <#assign userIsLoggedIn = isUserLoggedIn() />
+            <@siteLink handlerName="userLogin" queryParameters={"page": getLinkToCurrentPage()?url('UTF-8')} ; login>
               <a title="Report a Concern" class="flag toolbar btn"
                 <#if userIsLoggedIn>
                  onclick="comments.showReportBox('${commentId?c}'); return false;"

--- a/src/main/webapp/WEB-INF/themes/root/ftl/macro/userSession.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/macro/userSession.ftl
@@ -1,0 +1,18 @@
+<#--
+  Return a boolean value indicating whether the user has a logged-in session.
+  -->
+<#function isUserLoggedIn>
+  <#return Session["SPRING_SECURITY_CONTEXT"]?exists && Session["SPRING_SECURITY_CONTEXT"].authentication.authenticated />
+</#function>
+
+<#--
+  Return a link to the page being served, which typically will be used as the "page" parameter of a link to the
+  "userLogin" handler. This is necessary for the user to be directed back to the current page after logging in.
+  -->
+<#function getLinkToCurrentPage>
+  <#if requestContext.getQueryString()?exists >
+    <#return requestContext.getRequestUri() + "?" + requestContext.getQueryString() />
+  <#else>
+    <#return requestContext.getRequestUri() />
+  </#if>
+</#function>


### PR DESCRIPTION
Reuses code from the regular login button in the nav top template (in PLOS
themes), which is extracted into a new reusable file.
