### PR TITLE
DPRO-1910: Debug error-handling on taxonomy endpoint

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/TaxonomyController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/TaxonomyController.java
@@ -69,8 +69,8 @@ public class TaxonomyController {
     }
     req += "journal=" + site.getJournalKey();
     response.setContentType("application/json");
-    try (OutputStream output = response.getOutputStream();
-         InputStream input = soaService.requestStream(req)) {
+    try (InputStream input = soaService.requestStream(req);
+         OutputStream output = response.getOutputStream()) {
       IOUtils.copy(input, output);
     }
   }


### PR DESCRIPTION
This change prevents an error where "IllegalStateException:
getOutputStream() has already been called for this response" was logged to
the console, obscuring another error.

The fix is to request the service input stream before opening the output
stream. If an exception occurs on the service request, our normal
exception-handling code will attempt to open the output stream again.
So, we don't open the output stream until we're sure we can write to it.
