### PR TITLE
DPRO-2046: Debug race condition in building RequestMappingContextDictionary

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/site/RequestMappingContextDictionary.java
+++ b/src/main/java/org/ambraproject/wombat/config/site/RequestMappingContextDictionary.java
@@ -118,9 +118,9 @@ public final class RequestMappingContextDictionary {
      */
     if (!isFrozen) {
       synchronized (writeLock) {
-        isFrozen = true;
         siteTable = ImmutableTable.copyOf(siteTableBuilder);
         globalTable = ImmutableMap.copyOf(globalTableBuilder);
+        isFrozen = true;
       }
     }
   }


### PR DESCRIPTION
If the first thread is between "isFrozen = true" and initializing the
tables, a second thread could skip the "if (!isFrozen)" block and attempt
to read the tables before the first thread is done initializing them.
