### PR TITLE
DPRO-1903: Point "Media Coverage" link to Related Content controller

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mediaCoverageLink.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mediaCoverageLink.ftl
@@ -1,5 +1,0 @@
-<#--
-  Subthemes may override this file to invoke the mediaCoverageLink macro,
-  in order to provide a link to an ALM-backed media coverage page
-  (typically a "Related Content" tab supported by legacy Ambra -- to be supported here in the future).
-  -->

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/nav.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/nav.ftl
@@ -5,14 +5,11 @@
       <a href="article/comments?id=${article.doi}">Reader Comments (${articleComments?size})</a>
     </li>
 
-  <#macro mediaCoverageLink href>
     <li class="nav-media" id="nav-media" data-doi="${article.doi}">
-      <a href="${href}">
+      <a href="<@siteLink handlerName="articleRelatedContent" queryParameters={"id": article.doi} />">
         Media Coverage <span id="media-coverage-count"></span>
       </a>
     </li>
-  </#macro>
-  <#include "mediaCoverageLink.ftl" />
 
   <#if article.figures?? && article.figures?size &gt; 0 >
     <li id="nav-figures"><a href="#" data-doi="${article.doi}">Figures</a></li>


### PR DESCRIPTION
Removed override hook for providing an external link.
