### PR TITLE
DPRO-2129 - [Figure Lightbox] - Reset zoom slider and retract caption on image change

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/lightbox.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/lightbox.js
@@ -202,6 +202,9 @@ var FigureLightbox = {};
     $(this.lbSelector + ' #image-context').children().remove().end()
         // Append new img context
         .append(lbTemplate(templateData));
+    if (this.descriptionExpanded) {
+      this.retractDescription();
+    }
     this.renderImg(this.imgData.doi);
 
     if (!this.descriptionExpanded) {
@@ -376,6 +379,12 @@ var FigureLightbox = {};
     var that = this;
     this.$panZoomEl.off('panzoomzoom').on('panzoomzoom', function(e, panzoom, scale) {
       $(that.zoomRangeSelector).foundation('slider', 'set_value', scale);
+      // Bug in foundation unbinds after set_value. Workaround: rebind everytime
+      that.bindPanZoomToSlider();
+    });
+
+    this.$panZoomEl.off('panzoomreset').on('panzoomreset', function(e) {
+      $(that.zoomRangeSelector).foundation('slider', 'set_value', 1);
       // Bug in foundation unbinds after set_value. Workaround: rebind everytime
       that.bindPanZoomToSlider();
     });


### PR DESCRIPTION
The image zoom was resetting but the slider don't - Fixed. The issue mentioned that the caption was not closing when the image is change, in my test the behavior happened as expected, to ensure I made a change that verifies if the caption is closed, if it's not, closes it.
