### PR TITLE
DPRO-2127 - [Figure Lightbox] - Main image centralised in the viewport when initiated

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/lightbox.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/lightbox.js
@@ -441,6 +441,7 @@ var FigureLightbox = {};
       $(that.zoomRangeSelector).foundation('slider', 'set_value', 20);
       // Bug in foundation unbinds after set_value. Workaround: rebind everytime
       that.bindPanZoomToSlider();
+      //Centers the image in the viewport everytime the panzoom resets
       that.calculateImageTopPosition();
     });
   };


### PR DESCRIPTION
I created a function that nows calculate the correct top position of the image, to be in the center of the viewport, every time the panZoom plugin resets.
