### PR TITLE
DPRO-2179: Remove "canonical" metadata link from articles

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/metaTags.ftl
@@ -47,10 +47,6 @@
 <#--//crossmark identifier-->
 <meta name="dc.identifier" content="${article.doi}" />
 
-<#if pubUrlPrefix?has_content>
-<link rel="canonical" href="${pubUrlPrefix}article?id=${article.doi}" />
-</#if>
-
 <#if article.description??>
   <#if twitterUsername?has_content>
   <meta name="twitter:card" content="summary" />


### PR DESCRIPTION
It was being misused. It should point to the canonical source only if it is
different from the page that it appears on.
