### PR TITLE
DPRO-2222 - process feed img

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/blogfeed.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/blogfeed.js
@@ -21,11 +21,14 @@ function feedLoaded(blog_feed, blogPostCount, blogContainer) {
           if (postTitle.length > 75) {
             postTitle = postTitle.slice(0, 70) + "&hellip;";
           }
-          // TODO - need to move the link to the default image out of the JS.
+
           blogImg = entry.thumbnail;
           if (blogImg == null) {
             blogImg = "resource/img/generic_blogfeed.png";
           }
+
+          // TODO - need to move the link to the default image out of the JS.
+// Wordpress spits out a string for thumbnail that is set up for use in the "srcSET" attribute. IE doesnt' support this so we break on a space because it outputs the smallest image first.
           blogImgString = blogImg.split(" ");
           blogImgRefined = blogImgString[0];
 


### PR DESCRIPTION
- for IE and browser that do not support srcset we split the image feed
  url
- use the original feed in srcset
