### PR TITLE
DPRO-2224 - [Figure Lightbox] - Increase height of zoom slider for touch devices

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article-lightbox.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article-lightbox.scss
@@ -278,6 +278,19 @@ $lb-footer-height: $lb-control-bar-height + $lb-description-bar-height + $lb-hea
           width: 100%;
           margin: rem-calc(12px) 0;
           background-color: rgba(255,255,255,0.64);
+
+          html.touch & {
+            height: rem-calc(24);
+            margin: rem-calc(8) 0;
+
+            .range-slider-handle {
+              height: rem-calc(30);
+            }
+
+            .range-slider-active-segment {
+              height: rem-calc(22);
+            }
+          }
         }
 
         #lb-zoom-min,


### PR DESCRIPTION
In touch devices the slider was too thin and the touch screen could not recognise the click.
