### PR TITLE
DPRO-2209: Add Solr's "NOT" operator to advanced search query options

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/search/advancedSearchQueryBuilder.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/search/advancedSearchQueryBuilder.ftl
@@ -8,6 +8,7 @@
             <select class="operator">
                 <option value="AND">AND</option>
                 <option value="OR">OR</option>
+                <option value="NOT">NOT</option>
             </select>
         </div>
         <div class="advanced-search-col-3">


### PR DESCRIPTION
One of those where it takes 30 seconds to add the code and a lot longer to figure out if it's the right thing. :wink: 

I messed around with queries built with this option for a while. I'm pretty sure it behaves correctly in terms of interacting with AND and OR, etc. If the "NOT" operator needs any more special handling than this, I haven't found out how.
