### PR TITLE
DPRO-2300: Prevent double-encoding of JSON

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleController.java
@@ -494,8 +494,7 @@ public class ArticleController extends WombatController {
     ArticleComment comment = new ArticleComment(parentArticleDoi, getUserIdFromAuthId(authId),
         parentCommentUri, commentTitle, commentBody, ciStatement);
 
-    String articleCommentJson = new Gson().toJson(comment);
-    HttpUriRequest commentPostRequest = createJsonPostRequest(forwardedUrl, articleCommentJson);
+    HttpUriRequest commentPostRequest = createJsonPostRequest(forwardedUrl, comment);
     try (CloseableHttpResponse response = articleApi.getResponse(commentPostRequest)) {
       String createdCommentUri = HttpMessageUtil.readResponse(response);
       return ImmutableMap.of("createdCommentUri", createdCommentUri);


### PR DESCRIPTION
This bug crept in during a merge. It made the request body a JSON string
containing an escaped JSON object.
