### PR TITLE
DPRO-2217 - MathJax version update

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
@@ -2,7 +2,7 @@
 <!-- more can be found at http://docs.mathjax.org/en/latest/ -->
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
-  jax: ["output/CommonHTML"]
+  jax: ["output/CommonHTML", "output/HTML-CSS"]
 });
 </script>
 


### PR DESCRIPTION
I updated the MathJax from 2.1 to 2.6 and many rendering problems have been fixed, but, almost all formulas were breaking in two lines, to solve this problem I change the output render to CommonHTML and took off the configuration for HTML-CSS render.
