### PR TITLE
DPRO-2331 add EntityNotFoundException to the list of exceptions handl…

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/remote/UserApiImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/UserApiImpl.java
@@ -99,12 +99,7 @@ public class UserApiImpl extends AbstractRestfulJsonApi implements UserApi {
   public final String getUserIdFromAuthId(String authId) throws IOException {
     Objects.requireNonNull(authId);
     final IndividualComposite individualComposite;
-    try {
-      individualComposite = requestObject(String.format("individuals/CAS/%s", authId), IndividualComposite.class);
-    } catch (EntityNotFoundException e) {
-      throw new UserApiException("No IndividualComposite found with authId=" + authId, e);
-    }
-
+    individualComposite = requestObject(String.format("individuals/CAS/%s", authId), IndividualComposite.class);
     // use nedid from any available profile.
     Individualprofile individualprofile = individualComposite.getIndividualprofiles().stream()
         .findFirst()


### PR DESCRIPTION
…ed by UserApiImlp

@rskonnord-plos I added the exception to the list after talking to Jono and verifying that the bug doesn't exist in their dev environment. He said the only time they return 404 is for invalid endpoint (which is a default behavior anyway).

I also tested posting a comment with an invalid CAS and it never hist the catch block in `getUserIdFromAuthId`, so I removed it. From the logs: 

> org.ambraproject.wombat.service.remote.ServiceRequestException:
> 
> Request to "/v1/individuals/CAS/CLVEJD4XQO8DLE5FS8PBB91TYKODDTIT" failed (400): Bad 
> Request.
