### PR TITLE
DPRO-2792: Allow configuration directory to be injected

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/RootConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/RootConfiguration.java
@@ -21,7 +21,6 @@ import org.ambraproject.wombat.service.remote.UserApiImpl;
 import org.ambraproject.wombat.util.JodaTimeLocalDateAdapter;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.yaml.snakeyaml.Yaml;
@@ -43,34 +42,20 @@ public class RootConfiguration {
   }
 
   private static final String CONFIG_DIR_PROPERTY_NAME = "wombat.configDir";
-  private static final String CONFIG_DIR_ENVIRONMENT_NAME = "WOMBAT_CONFIG_DIR";
 
-  private static File getConfigDirectory(ApplicationContext applicationContext) {
+  private static File getConfigDirectory() {
     String property = System.getProperty(CONFIG_DIR_PROPERTY_NAME);
     if (!Strings.isNullOrEmpty(property)) {
       return new File(property);
+    } else {
+      throw new RuntimeException("Config directory not found. " + CONFIG_DIR_PROPERTY_NAME + " must be defined.");
     }
-
-    String environmentVar = System.getenv(CONFIG_DIR_ENVIRONMENT_NAME);
-    if (!Strings.isNullOrEmpty(environmentVar)) {
-      return new File(environmentVar);
-    }
-
-    String applicationName = applicationContext.getApplicationName();
-    if (!Strings.isNullOrEmpty(applicationName)) {
-      return new File("/etc", applicationName);
-    }
-
-    throw new RuntimeException("Config directory not found. " +
-        "(If application name is empty, " + CONFIG_DIR_PROPERTY_NAME + " or "
-        + CONFIG_DIR_ENVIRONMENT_NAME + " must be defined.)");
   }
 
   @Bean
-  public RuntimeConfiguration runtimeConfiguration(ApplicationContext applicationContext,
-                                                   Yaml yaml)
+  public RuntimeConfiguration runtimeConfiguration(Yaml yaml)
       throws IOException {
-    File configDirectory = getConfigDirectory(applicationContext);
+    File configDirectory = getConfigDirectory();
     File configPath = new File(configDirectory, "wombat.yaml");
     if (!configPath.exists()) {
       throw new RuntimeConfigurationException(configPath.getPath() + " not found");


### PR DESCRIPTION
**Please hold off on merging until we settle on the config contract and come up with a plan for changing deployments.**

This will change the config location from the hard-coded and unchangeable `/etc/ambra/` to `/etc/{application name}/` (where the application name would be `wombat`), which can be overridden either with a system property `wombat.configDir` or an environment variable `WOMBAT_CONFIG_DIR`.

A development setup that runs from the Maven Tomcat plugin and keeps everything in `/etc/ambra/` can continue without any other changes by adding `-Dwombat.configDir=/etc/ambra`.

Currently there is a difference from Rhino, in that there are challenges with supporting both the default and the environment variable, meaning Rhino requires a system property for all instances. (See https://github.com/PLOS/rhino/pull/231.) We may wish to consider dropping the default and/or environment variable options from Wombat, for consistency with Rhino or just because it's simpler that way.
