### PR TITLE
DPRO-2732: Avoid querying for too many articles in getAllArticlesByType

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/RecentArticleServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/RecentArticleServiceImpl.java
@@ -148,6 +148,8 @@ public class RecentArticleServiceImpl implements RecentArticleService {
             "(2) use the wildcard type parameter (*).";
         throw new RuntimeException(errorMessage);
       } else {
+        // Not enough results. Get outside the date range in order to meet the minimum.
+        // Ignore order of articleTypes and get the union of all.
         int limit = articleCount - articles.size();
         articles.addAll(getAllArticlesByType(articleTypes, articleTypesToExclude, journalKeys, limit));
       }


### PR DESCRIPTION
The query is made only when we are going beyond the normal date range in order to fill out the recent articles list. We need only the minimum number to fill the list, because we no longer care about shuffling or ordering by article type.
