### PR TITLE
DPRO-3009: return empty response object to ajax post request 

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/TaxonomyController.java
+++ b/src/main/java/org/ambraproject/wombat/controller/TaxonomyController.java
@@ -15,7 +15,6 @@ package org.ambraproject.wombat.controller;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.config.site.SiteParam;
 import org.ambraproject.wombat.model.TaxonomyCountTable;
@@ -144,7 +143,7 @@ public class TaxonomyController extends WombatController {
 
   @RequestMapping(name = "taxonomyCategoryFlag", value = "" + TAXONOMY_NAMESPACE + "flag/{action:add|remove}", method = RequestMethod.POST)
   @ResponseBody
-  public Object setFlag(HttpServletRequest request, HttpServletResponse responseToClient,
+  public void setFlag(HttpServletRequest request, HttpServletResponse responseToClient,
                       @PathVariable(value = "action") String action,
                       @RequestParam(value = "categoryTerm", required = true) String categoryTerm,
                       @RequestParam(value = "articleDoi", required = true) String articleDoi)
@@ -160,7 +159,6 @@ public class TaxonomyController extends WombatController {
     }
 
     articleApi.postObject(address.build(), null);
-    return ImmutableMap.of();
   }
 
   /**

--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/pages/article_sidebar.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/pages/article_sidebar.js
@@ -76,7 +76,6 @@
                 type:     'POST',
                 url:      siteUrlPrefix + 'taxonomy/flag/' + action,
                 data:     {'categoryTerm': categoryTerm, 'articleDoi': article_doi},
-                dataType: 'json',
                 error:    function (errorThrown) {
                   $('#subjectErrors').append(errorThrown);
                 },


### PR DESCRIPTION
This is necessary in order to trigger javascript `success()` method on return
