### PR TITLE
DPRO-3082: Disable canViewUnpublishedIngestion

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/DoiVersionArgumentResolver.java
+++ b/src/main/java/org/ambraproject/wombat/controller/DoiVersionArgumentResolver.java
@@ -25,7 +25,7 @@ public class DoiVersionArgumentResolver implements HandlerMethodArgumentResolver
    * @return {@code true} if the user is authorized to view unpublished content
    */
   private boolean canViewUnpublishedIngestion(NativeWebRequest webRequest) {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Disabling this functionality so as not to expose content at release, until there is a configurable way to turn it back on.