### PR TITLE
DPRO-3156: Debug NPE on citation download when article has no description

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/CitationDownloadServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/CitationDownloadServiceImpl.java
@@ -55,10 +55,12 @@ public class CitationDownloadServiceImpl implements CitationDownloadService {
       appendRisCitationLine(citation, "A1", formatAuthorName(author, "surnames", "givenNames", "suffix"));
     }
 
+    String descriptionXml = (String) articleMetadata.get("description");
+    String descriptionText = (descriptionXml == null) ? null : XmlUtil.extractText(descriptionXml);
     String journalTitle = extractJournalTitle(articleMetadata);
 
     appendRisCitationLine(citation, "Y1", formatPublicationDate(articleMetadata, RIS_DATE_FORMAT));
-    appendRisCitationLine(citation, "N2", XmlUtil.extractText((String) articleMetadata.get("description")));
+    appendRisCitationLine(citation, "N2", descriptionText);
     appendRisCitationLine(citation, "JF", journalTitle);
     appendRisCitationLine(citation, "JA", journalTitle);
     appendRisCitationLine(citation, "VL", (String) articleMetadata.get("volume"));
@@ -121,7 +123,8 @@ public class CitationDownloadServiceImpl implements CitationDownloadService {
     ABSTRACT("abstract", "description") {
       @Override
       protected String extractValue(Map<String, ?> articleMetadata) {
-        return XmlUtil.extractText(super.extractValue(articleMetadata));
+        String value = super.extractValue(articleMetadata);
+        return (value == null) ? null : XmlUtil.extractText(value);
       }
     },
     NUMBER("number", "issue"),


### PR DESCRIPTION
Considered instead having XmlUtil.extractText return null for a null
argument, but that would be a little uglier and also inconsistent with
extractElement, etc.

Also considered adding similar checks in CitationDownloadServiceImpl for
title, since it is handled similarly to description. But title is expected
always to be present, so failing loudly is fine.