### PR TITLE
DPRO-3487: trim incoming doi requests in wombat to ignore trailing %20s

### DIFF
--- a/src/main/java/org/ambraproject/wombat/identity/RequestedDoiVersion.java
+++ b/src/main/java/org/ambraproject/wombat/identity/RequestedDoiVersion.java
@@ -47,7 +47,7 @@ public class RequestedDoiVersion {
     Preconditions.checkArgument(!revisionNumber.isPresent() || revisionNumber.getAsInt() >= 0);
     Preconditions.checkArgument(!ingestionNumber.isPresent() || ingestionNumber.getAsInt() >= 0);
 
-    this.doi = Objects.requireNonNull(doi);
+    this.doi = Objects.requireNonNull(doi.trim());
     this.revisionNumber = revisionNumber;
     this.ingestionNumber = ingestionNumber;
   }


### PR DESCRIPTION
@msingh05 
@anilop 

Very simple fix. Google Analytics should be unaffected