### PR TITLE
Make solr configuration optional

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/YamlConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/YamlConfiguration.java
@@ -253,7 +253,7 @@ public class YamlConfiguration implements RuntimeConfiguration {
     } catch (MalformedURLException e) {
       throw new RuntimeConfigurationException("Provided server address is not a valid URL", e);
     }
-    if (!Strings.isNullOrEmpty(input.solr.url)) {
+    if (input.solr != null && !Strings.isNullOrEmpty(input.solr.url)) {
       try {
         new URL(input.solr.url);
       } catch (MalformedURLException e) {


### PR DESCRIPTION
Previously, if `wombat.yaml` did not define a `solr` heading, this code would throw a NPE.
```
...
Caused by: java.lang.NullPointerException
	at org.ambraproject.wombat.config.YamlConfiguration$SolrConfigurationInput.access$2100(YamlConfiguration.java:485)
	at org.ambraproject.wombat.config.YamlConfiguration.validate(YamlConfiguration.java:256)
	at org.ambraproject.wombat.config.RootConfiguration.runtimeConfiguration(RootConfiguration.java:92)
	at org.ambraproject.wombat.config.RootConfiguration$$EnhancerBySpringCGLIB$$efdbbf06.CGLIB$runtimeConfiguration$2(<generated>)
	at org.ambraproject.wombat.config.RootConfiguration$$EnhancerBySpringCGLIB$$efdbbf06$$FastClassBySpringCGLIB$$795f1b7c.invoke(<generated>)
```

This prevents the NPE by testing if `input.solr` is `null` before calling `input.solr.url`.

This is useful because solr is supposedly optional for Wombat.