### PR TITLE
Use / as the path when starting wombat with mvn tomcat6:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,7 @@
         <artifactId>tomcat6-maven-plugin</artifactId>
         <version>2.1</version>
         <configuration>
+          <path>/</path>
           <systemProperties>
             <java.util.logging.manager>org.apache.juli.ClassLoaderLogManager</java.util.logging.manager>
             <org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH>true


### PR DESCRIPTION
The root (`/`) context is used by rhino and wombat when starting with the tomcat maven plugin. This changes wombat to use it also.