### PR TITLE
Upgrade to tomcat7 maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,8 +361,8 @@
     <plugins>
       <plugin>
         <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat6-maven-plugin</artifactId>
-        <version>2.1</version>
+        <artifactId>tomcat7-maven-plugin</artifactId>
+        <version>2.2</version>
         <configuration>
           <path>/</path>
           <systemProperties>


### PR DESCRIPTION
We use tomcat 7 in production, we should upgrade the maven plugin used for testing.