### PR TITLE
AMBR-3 debian: install wombat in root context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
                 <data>
                   <src>${project.build.directory}/${project.build.finalName}.war</src>
                   <type>file</type>
-                  <dst>/opt/plos/wombat/webapps/wombat.war</dst>
+                  <dst>/opt/plos/wombat/webapps/ROOT.war</dst>
                 </data>
 
                 <data>


### PR DESCRIPTION
By installing in `wombat.war`, a user will need to visit: `http://hostname:PORT/wombat/` to see rhino.

Our salt scripts all rename `wombat.war` to `ROOT.war` to listen at `http://hostname:PORT/`

This is overly complicated, in my opinion. Why not simply put it in `ROOT.war` in the debian package and skip the salt step?

Advantages:
- Installing the debian package works properly, and we do not need to run salt afterwards to get the proper setup
- Reduces the amount of salt code

This should be safely mergeable without any change to salt, because the salt file move will noop if not necessary, and we can remove the salt code later.