### PR TITLE
AMBR-3 debian: do not db_purge in postinst

### DIFF
--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -55,13 +55,10 @@ case "$1" in
 
 ########### END app-specific code ###########
 
-	echo "Running db_purge"
-	db_purge
-
 	process_env_template $HOME/conf/context.template.xml $HOME/conf/context.xml
 
 	process_env_template $HOME/conf/server.template.xml $HOME/conf/server.xml
-	
+
 	process_env_template $HOME/conf/tomcat-users.template.xml $HOME/conf/tomcat-users.xml
 
 	process_env_template $HOME/bin/setenv.template.sh $HOME/bin/setenv.sh


### PR DESCRIPTION
debian packages should not clear the questions answered when installing. This
should happen when the package is purged.