### PR TITLE
AMBR-205 : Removed trailing '.' for non-journal references.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -2247,11 +2247,11 @@
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates/>
+              <xsl:if test="substring(.,string-length(.)) != '.' and not(ends-with(..,'.'))">
+                <xsl:text>. </xsl:text>
+              </xsl:if>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:if test="substring(.,string-length(.)) != '.' and not(ends-with(..,'.'))">
-          <xsl:text>. </xsl:text>
-          </xsl:if>
         </xsl:if>
       </xsl:otherwise>
 


### PR DESCRIPTION
This PR removes the trailing '.' at the end of the DOI reference for non-article types.

![image](https://user-images.githubusercontent.com/29076178/37492709-9ba3df6a-285f-11e8-9c2f-51eef7299947.png)
