### PR TITLE
AMBR-387 : Replaced help using this site link.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/common/header/browse.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/common/header/browse.ftl
@@ -29,7 +29,7 @@
       <div id="subjInfoText">
         <p>Click through the PLOS taxonomy to find articles in your field.</p>
         <p>For more information about PLOS Subject Areas, click
-          <a href="<@siteLink path='s/help-using-this-site#loc-subject-areas'/>">here</a>.
+          <a href="https://github.com/PLOS/plos-thesaurus/blob/develop/README.md" target="_blank" title="Link opens in new window">here</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
This PR replaces the link from `/s/help-using-this-site#loc-subject-areas` to `https://github.com/PLOS/plos-thesaurus/blob/develop/README.md`.