### PR TITLE
AMBR-420 : Explicitly HTML escaped the comment title.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comment.ftl
@@ -142,7 +142,7 @@
             >
 
           <div class="info">
-            <h3 class="response_title">${comment.title}</h3>
+            <h3 class="response_title">${comment.title?html}</h3>
             <h4>
               <#if depth == 0>
                 Posted by <@userInfoLink user=comment.creator class="user icon replyCreator" />

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comments.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/comment/comments.ftl
@@ -19,13 +19,11 @@
   ~ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
   ~ DEALINGS IN THE SOFTWARE.
   -->
-
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       lang="en" xml:lang="en"
       itemscope itemtype="http://schema.org/Article"
       class="no-js">
-
 
 <#assign title = article.title />
 <#assign articleDoi = article.doi />
@@ -67,7 +65,7 @@
             </div>
             <div class="title">
               <a href="<@siteLink handlerName="articleCommentTree" queryParameters={"id": comment.commentUri} />">
-              ${comment.title}
+              ${comment.title?html}
               </a>
             <span>
               <#include "userInfoLink.ftl" />


### PR DESCRIPTION
This PR forces the `comment.title` to be escaped so that HTML tags are rendered as literal strings.  For example, it escapes:
```
< > & "  '
```
as
```
&lt; &gt; &amp; &quot; &#39;
```