### PR TITLE
AMBR-422 : CSS Styling to fix author page on mobile.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
@@ -520,7 +520,11 @@ $article-sidebar-width: 160;
     margin-right: $icon-space;
   }
   .orcid span.type {display: none;}
+}
 
+#orcid-id-logo {
+  float: left;
+  padding-right: 4px;
 }
 
 .author-list .active {
@@ -570,7 +574,6 @@ $article-sidebar-width: 160;
   font-family: $font-face-plain;
   font-size: $txt-size-xxxsmall;
 }
-
 
 
 // RIGHT COLUMN STYLES

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/mobile.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/mobile.css
@@ -799,6 +799,12 @@ html:not(.positionfixed) #page-figure #site-header-container {
   margin-bottom: 20px;
 }
 
+/* line 525, sass/pages/_article.scss */
+#orcid-id-logo {
+  float: left;
+  padding-right: 4px;
+}
+
 .modal-content .comment-markup {
   font-size: 1.1em;
   margin-bottom: 20px;

--- a/src/main/webapp/WEB-INF/themes/root/ftl/article/authorItem.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/article/authorItem.ftl
@@ -59,14 +59,14 @@
   </p>
   </#if>
   <#if author.orcid?? && author.orcid.authenticated>
+  <div>
   <p class="orcid" id="authOrcid-${author_index?c}">
     <span>
-      <a id="connect-orcid-link" href="${author.orcid.value}" target="_blank" title="ORCID Registry">
-        <img id="orcid-id-logo" src="<@siteLink path="/resource/img/orcid_16x16.png"/>" width='16' height='16' alt="ORCID logo"/>
-      </a>
+      <a id="connect-orcid-link" href="${author.orcid.value}" target="_blank" title="ORCID Registry"><img id="orcid-id-logo" src="<@siteLink path="/resource/img/orcid_16x16.png"/>" width="16" height="16" alt="ORCID logo"/></a>
     </span>
     <a href="${author.orcid.value}">${author.orcid.value}</a>
   </p>
+  </div>
   </#if>
 
 </#macro>

--- a/src/main/webapp/WEB-INF/themes/root/ftl/article/authorItem.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/article/authorItem.ftl
@@ -62,7 +62,9 @@
   <div>
   <p class="orcid" id="authOrcid-${author_index?c}">
     <span>
-      <a id="connect-orcid-link" href="${author.orcid.value}" target="_blank" title="ORCID Registry"><img id="orcid-id-logo" src="<@siteLink path="/resource/img/orcid_16x16.png"/>" width="16" height="16" alt="ORCID logo"/></a>
+      <a id="connect-orcid-link" href="${author.orcid.value}" target="_blank" title="ORCID Registry">
+        <img id="orcid-id-logo" src="<@siteLink path="/resource/img/orcid_16x16.png"/>" width="16" height="16" alt="ORCID logo"/>
+      </a>
     </span>
     <a href="${author.orcid.value}">${author.orcid.value}</a>
   </p>


### PR DESCRIPTION
This PR fixes the ORCID image not rendering properly on mobile, by adding CSS to allow image and text to be on the same row.

![image](https://user-images.githubusercontent.com/29076178/40739961-5dbb8b48-63fc-11e8-8919-1303c1649ead.png)
