### PR TITLE
AMBR-439 : Explicitly HTML escaped the rendered stacktrace.

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/error/error.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/error/error.ftl
@@ -43,7 +43,7 @@
        <p>Thank you for your patience.</p>
 
        <div title="+&nbsp;Technical Information for Developers">
-         <pre>${stackTrace}</pre>
+         <pre>${stackTrace?html}</pre>
        </div>
 
      </div>

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/error/error.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/error/error.ftl
@@ -35,6 +35,6 @@
 <p>Thank you for your patience.</p>
 
 <div class="collapsible" title="+&nbsp;Technical Information for Developers">
-  <pre>${stackTrace}</pre>
+  <pre>${stackTrace?html}</pre>
 </div>
 <@page_footer />

--- a/src/main/webapp/WEB-INF/themes/root/app/error.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/app/error.ftl
@@ -43,7 +43,7 @@
 
     <div id="stackTrace">
       <h2>Technical Information for Developers</h2>
-      <pre>${stackTrace}</pre>
+      <pre>${stackTrace?html}</pre>
     </div>
 
   </div>

--- a/src/main/webapp/WEB-INF/themes/root/ftl/error/error.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/error/error.ftl
@@ -37,7 +37,7 @@
   <p>Thank you for your patience.</p>
 
   <div title="+&nbsp;Technical Information for Developers">
-    <pre>${stackTrace}</pre>
+    <pre>${stackTrace?html}</pre>
   </div>
 </div>
 


### PR DESCRIPTION
This PR explicitly HTML escapes the rendered stacktrace.  However, it looks like the template to render the wombat error page is in [plos-themes](https://github.com/PLOS/plos-themes/blob/develop/code/desktop/all_sites/ftl/error/error.ftl).   So, there's a correspond [PR](https://github.com/PLOS/plos-themes/pull/897) in **plos-themes** to fix the XSS issue.