### PR TITLE
AMBR-574 - call crossref search API via HTTPS

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/pages/article_references.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/pages/article_references.js
@@ -46,9 +46,9 @@
 
           var queryStringConcat = (queryStringAuthor ? 'query.author=' + queryStringAuthor + '&' : '')
             + 'query.title=' + queryStringTitle;
-          var crossrefApi = "http://api.crossref.org/works?query=" + queryStringConcat + "&sort=score&rows=1";
+          var crossrefApi = "https://api.crossref.org/works?query=" + queryStringConcat + "&sort=score&rows=1";
           var DOIResolver = 'https://doi.org/';
-          var crossrefSearchString = 'http://search.crossref.org/?q=' + queryStringCit;
+          var crossrefSearchString = 'https://search.crossref.org/?q=' + queryStringCit;
           var articleLink = null;
 
 


### PR DESCRIPTION

When the view article link is clicked we query crossref search API for the article via the http endpoint.  in https this causes a CORS error. calling the API through https fixes the error. 
