### PR TITLE
Ambr 218 encode math as data uri

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/SpringConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/SpringConfiguration.java
@@ -81,6 +81,7 @@ import org.ambraproject.wombat.service.CommentService;
 import org.ambraproject.wombat.service.CommentServiceImpl;
 import org.ambraproject.wombat.service.CommentValidationService;
 import org.ambraproject.wombat.service.CommentValidationServiceImpl;
+import org.ambraproject.wombat.service.DataUriEncodeFunction;
 import org.ambraproject.wombat.service.DoiToJournalResolutionService;
 import org.ambraproject.wombat.service.FreemarkerMailService;
 import org.ambraproject.wombat.service.FreemarkerMailServiceImpl;
@@ -323,6 +324,11 @@ public class SpringConfiguration {
   @Bean
   public ArticleResolutionService articleResolutionService() {
     return new ArticleResolutionService();
+  }
+
+  @Bean
+  public DataUriEncodeFunction dataUriEncodeFunction() {
+    return new DataUriEncodeFunction();
   }
 
   @Bean

--- a/src/main/java/org/ambraproject/wombat/service/ArticleService.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleService.java
@@ -29,6 +29,7 @@ import org.ambraproject.wombat.service.remote.ContentKey;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Service class that deals with article metadata.
@@ -52,4 +53,6 @@ public interface ArticleService {
   Map<String, ?> getItemFiles(AssetPointer assetId) throws IOException;
 
   ContentKey getManuscriptKey(ArticlePointer articleId) throws IOException;
+
+  Optional<ContentKey> getThumbnailKey(RequestedDoiVersion doi);
 }

--- a/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
@@ -95,7 +95,11 @@ public class ArticleServiceImpl implements ArticleService {
     try {
       AssetPointer asset = articleResolutionService.toParentIngestion(doi);
       Map<String, ?> files = getItemFiles(asset);
-      return Optional.of(createKeyFromMap((Map<String, String>) files.get("thumbnail")));
+      if (files.containsKey("thumbnail")) {
+        return Optional.of(createKeyFromMap((Map<String, String>) files.get("thumbnail")));
+      } else {
+        return Optional.empty();
+      }
     } catch (IOException ex) {
       return Optional.empty();
     }

--- a/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
@@ -81,6 +81,7 @@ public class ArticleServiceImpl implements ArticleService {
     Map<String, ?> articleFiles = (Map<String, ?>) articleItem.get("files");
     Map<String, ?> manuscriptPointer = (Map<String, ?>) articleFiles.get("manuscript");
 
+    // TODO: Use createKeyFromMap here.
     String crepoKey = (String) manuscriptPointer.get("crepoKey");
     UUID crepoUuid = UUID.fromString((String) manuscriptPointer.get("crepoUuid"));
     ContentKey key = ContentKey.createForUuid(crepoKey, crepoUuid);

--- a/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleServiceImpl.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ArticleServiceImpl implements ArticleService {
@@ -86,5 +87,26 @@ public class ArticleServiceImpl implements ArticleService {
     String bucketName = (String) manuscriptPointer.get("bucketName");
     key.setBucketName(bucketName);
     return key;
+  }
+
+  @Override
+  public Optional<ContentKey> getThumbnailKey(RequestedDoiVersion doi) {
+    try {
+      AssetPointer asset = articleResolutionService.toParentIngestion(doi);
+      Map<String, ?> files = getItemFiles(asset);
+      return Optional.of(createKeyFromMap((Map<String, String>) files.get("thumbnail")));
+    } catch (IOException ex) {
+      return Optional.empty();
+    }
+  }
+
+  public ContentKey createKeyFromMap(Map<String, String> fileRepoMap) {
+    String key = fileRepoMap.get("crepoKey");
+    UUID uuid = UUID.fromString(fileRepoMap.get("crepoUuid"));
+    ContentKey contentKey = ContentKey.createForUuid(key, uuid);
+    if (fileRepoMap.get("bucketName") != null) {
+      contentKey.setBucketName(fileRepoMap.get("bucketName"));
+    }
+    return contentKey;
   }
 }

--- a/src/main/java/org/ambraproject/wombat/service/ArticleTransformServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleTransformServiceImpl.java
@@ -163,6 +163,8 @@ public class ArticleTransformServiceImpl implements ArticleTransformService {
         versionNumber = articleId.getIngestionNumber();
       }
 
+      transformer.setParameter("ingestionNumber", articleId.getIngestionNumber());
+
       // Pre-build a snippet of a URL, meant to be concatenated onto a link in an HTML attribute.
       // Assumes that it will always be preceded by at least one other parameter,
       // else we would need a question mark instead of an ampersand.

--- a/src/main/java/org/ambraproject/wombat/service/ArticleTransformServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/ArticleTransformServiceImpl.java
@@ -60,8 +60,8 @@ import java.util.OptionalInt;
 public class ArticleTransformServiceImpl implements ArticleTransformService {
   private static final Logger log = LoggerFactory.getLogger(ArticleTransformServiceImpl.class);
 
-  private static final SiteTransformerFactory SITE_TRANSFORMER_FACTORY = new SiteTransformerFactory(
-      "xform/", "article-transform.xsl");
+  @Autowired
+  DataUriEncodeFunction dataUriEncodeFunction;
 
   @Autowired
   private Charset charset;
@@ -109,7 +109,7 @@ public class ArticleTransformServiceImpl implements ArticleTransformService {
   private Transformer buildTransformer(Site site, XMLReader xmlReader, TransformerInitializer initialization)
       throws IOException {
     log.debug("Building transformer for: {}", site);
-    Transformer transformer = SITE_TRANSFORMER_FACTORY.build(site);
+    Transformer transformer = new SiteTransformerFactory("xform/", "article-transform.xsl", dataUriEncodeFunction).build(site);
     initialization.initialize(xmlReader, transformer);
     return transformer;
   }

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -119,6 +119,12 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     XdmAtomicValue atomic = (XdmAtomicValue) item;
     return atomic.getStringValue();
   }
+  public RequestedDoiVersion getDoiFromArguments(XdmValue[] arguments) throws SaxonApiException {
+    String doi = extractString(arguments[1]);
+    int ingestionNumber = extractInt(arguments[2]);
+
+    return RequestedDoiVersion.ofIngestion(doi, ingestionNumber);
+  }
 
   @Override
   public XdmValue call(XdmValue[] arguments) throws SaxonApiException {

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -38,6 +38,7 @@ import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.SequenceType;
 import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmItem;
 import net.sf.saxon.s9api.XdmValue;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.identity.AssetPointer;
@@ -105,6 +106,18 @@ public class DataUriEncodeFunction implements ExtensionFunction {
       SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE),
       SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE)
     };
+  }
+
+  public static int extractInt(XdmValue value) throws SaxonApiException {
+    XdmItem item = value.itemAt(0);
+    XdmAtomicValue atomic = (XdmAtomicValue) item;
+    return Math.toIntExact(atomic.getLongValue());
+  }
+
+  public static String extractString(XdmValue value) {
+    XdmItem item = value.itemAt(0);
+    XdmAtomicValue atomic = (XdmAtomicValue) item;
+    return atomic.getStringValue();
   }
 
   @Override

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -174,4 +174,14 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     }
     return contentKey;
   }
+
+  public static ContentKey createKeyFromMap(Map<String, String> fileRepoMap) {
+    String key = fileRepoMap.get("crepoKey");
+    UUID uuid = UUID.fromString(fileRepoMap.get("crepoUuid"));
+    ContentKey contentKey = ContentKey.createForUuid(key, uuid);
+    if (fileRepoMap.get("bucketName") != null) {
+      contentKey.setBucketName(fileRepoMap.get("bucketName"));
+    }
+    return contentKey;
+  }
 }

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -61,33 +61,6 @@ import org.springframework.stereotype.Component;
 public class DataUriEncodeFunction implements ExtensionFunction {
   private static final Logger log = LoggerFactory.getLogger(DataUriEncodeFunction.class);
 
-  static enum AssetUrlStyle {
-    FIGURE_IMAGE("figureImage", "size", new String[]{"figure", "table", "standaloneStrikingImage"}),
-    ASSET_FILE("assetFile", "type", new String[]{"article", "supplementaryMaterial", "graphic"});
-
-    private final String handlerName;
-    private final String typeParameterName;
-    private final ImmutableSet<String> itemTypes;
-
-    private AssetUrlStyle(String handlerName, String typeParameterName, String[] itemTypes) {
-      this.handlerName = Objects.requireNonNull(handlerName);
-      this.typeParameterName = Objects.requireNonNull(typeParameterName);
-      this.itemTypes = ImmutableSet.copyOf(itemTypes);
-    }
-
-    private static final ImmutableMap<String, AssetUrlStyle> BY_ITEM_TYPE =
-        EnumSet.allOf(AssetUrlStyle.class).stream()
-            .flatMap((AssetUrlStyle s) -> s.itemTypes.stream()
-                .map((String itemType) -> Maps.immutableEntry(itemType, s)))
-            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-
-    static AssetUrlStyle findByItemType(String itemType) {
-      AssetUrlStyle style = BY_ITEM_TYPE.get(itemType);
-      if (style == null) throw new IllegalArgumentException("Unrecognized: " + itemType);
-      return style;
-    }
-  }
-
   @Autowired
   private CorpusContentApi corpusContentApi;
 

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -83,8 +83,12 @@ public class DataUriEncodeFunction implements ExtensionFunction {
   @Override
   public SequenceType[] getArgumentTypes() {
     return new SequenceType[] {
+      // Fallback
       SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE),
-      SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE)
+      // DOI
+      SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE),
+      // Ingestion Number
+      SequenceType.makeSequenceType(ItemType.INTEGER, OccurrenceIndicator.ONE)
     };
   }
 

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -43,6 +43,7 @@ import org.ambraproject.wombat.service.remote.ContentKey;
 import org.ambraproject.wombat.service.remote.CorpusContentApi;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,10 +170,10 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     XdmValue fallback = arguments[0];
     
     return getThumbnailContentKey(getDoiFromArguments(arguments))
-      .flatMap((contentKey)->corpusContentApi.optionalRequest(contentKey))
-      .map((request)->request.getEntity())
+      .flatMap(corpusContentApi::optionalRequest)
+      .map(CloseableHttpResponse::getEntity)
       .flatMap(DataUriEncodeFunction::encodeAsDataUrl)
-      .map((s) -> (XdmValue) new XdmAtomicValue(s))
+      .map((s)-> (XdmValue) new XdmAtomicValue(s)) // Is there a more succient way to do this?
       .orElse(fallback);
   }
 }

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -129,40 +129,7 @@ public class DataUriEncodeFunction implements ExtensionFunction {
   public XdmValue call(XdmValue[] arguments) throws SaxonApiException {
     XdmValue fallback = new XdmAtomicValue("article/file?type=thumbnail&id=" + arguments[0].toString() + arguments[0].toString());
 
-    try {
-      String doi = arguments[0].toString();
-      String version = arguments[1].toString();
-
-      AssetUrlStyle requestedStyle = AssetUrlStyle.ASSET_FILE;
-      Site site;
-      String fileType = "thumbnail";
-      Boolean isDownload = true;
-
-      RequestedDoiVersion id = RequestedDoiVersion.of(doi);
-      AssetPointer asset = articleResolutionService.toParentIngestion(id);
-      String type = "thumbnail";
-      Map<String, ?> itemMetadata = articleService.getItemMetadata(asset);
-      String itemType = (String) itemMetadata.get("itemType");
-      AssetUrlStyle itemStyle = AssetUrlStyle.findByItemType(itemType);
-
-      Map<String, ?> files = (Map<String, ?>) itemMetadata.get("files");
-      Map<String, ?> fileRepoKey = (Map<String, ?>) files.get(fileType);
-      ContentKey contentKey = createKey(fileRepoKey);
-      try (CloseableHttpResponse responseFromApi = corpusContentApi.request(contentKey, ImmutableList.of())) {
-        HttpEntity entity = responseFromApi.getEntity();
-        ContentType contentType = null;
-        if (entity != null) { contentType = ContentType.get(entity); }
-        if (contentType == null) {
-          return fallback;
-        } else {
-          byte[] body = IOUtils.toByteArray(responseFromApi.getEntity().getContent());
-          String dataUri = "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(body);
-          return new XdmAtomicValue(dataUri);
-        }
-      }
-    } catch (Exception ex) {
-      return fallback;
-    }
+    return fallback;
   }
 
   private static ContentKey createKey(Map<String, ?> fileRepoKey) {

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -65,7 +65,7 @@ public class DataUriEncodeFunction implements ExtensionFunction {
 
   @Override
   public QName getName() {
-    return new QName("http://www.ambraproject.org/xslt/", "embed-data-uri");
+    return new QName("http://www.ambraproject.org/xslt/", "embed-data-url");
   }
 
   @Override
@@ -139,7 +139,7 @@ public class DataUriEncodeFunction implements ExtensionFunction {
       try {
         return Optional.of(makeDataUrl(contentType, IOUtils.toByteArray(entity.getContent())));
       } catch (IOException ex) {
-        log.warn("Caught exception generating data-uri: {}", ex);
+        log.warn("Caught exception generating data-url: {}", ex);
         return Optional.empty();
       }
     }

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -145,6 +145,16 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     }
   }
   
+  /**
+   * Function to be used from within stylesheets. Will either encode a
+   * thumbnail as a data-url or return a fallback URL.
+   * @param arguments an array of XdmValue arguments passed in from
+   *   the stylesheet. The first is a fallback URL that will be
+   *   returned if there is a problem fetching any data. The second is
+   *   the doi. The third is the ingestion number to retrieve.
+   * @return either a data-url for the thumbnail content or the
+   *   fallback string
+   */
   @Override
   public XdmValue call(XdmValue[] arguments) throws SaxonApiException {
     XdmValue fallback = arguments[0];

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -145,31 +145,11 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     }
   }
   
-  private Optional<ContentKey> getThumbnailContentKey(RequestedDoiVersion doi) {
-    try {
-      AssetPointer asset = articleResolutionService.toParentIngestion(doi);
-      Map<String, ?> files = articleService.getItemFiles(asset);
-      return Optional.of(createKeyFromMap((Map<String, String>) files.get("thumbnail")));
-    } catch (IOException ex) {
-      return Optional.empty();
-    }      
-  }
-
-  public static ContentKey createKeyFromMap(Map<String, String> fileRepoMap) {
-    String key = fileRepoMap.get("crepoKey");
-    UUID uuid = UUID.fromString(fileRepoMap.get("crepoUuid"));
-    ContentKey contentKey = ContentKey.createForUuid(key, uuid);
-    if (fileRepoMap.get("bucketName") != null) {
-      contentKey.setBucketName(fileRepoMap.get("bucketName"));
-    }
-    return contentKey;
-  }
-
   @Override
   public XdmValue call(XdmValue[] arguments) throws SaxonApiException {
     XdmValue fallback = arguments[0];
     
-    return getThumbnailContentKey(getDoiFromArguments(arguments))
+    return articleService.getThumbnailKey(getDoiFromArguments(arguments))
       .flatMap(corpusContentApi::optionalRequest)
       .map(CloseableHttpResponse::getEntity)
       .flatMap(DataUriEncodeFunction::encodeAsDataUrl)

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -84,18 +84,35 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     };
   }
 
+  /**
+   * Extract a single int value from an XdmValue.
+   * @param value the XdmValue to extract from
+   * @return the int extracted
+   */
   public static int extractInt(XdmValue value) throws SaxonApiException {
     XdmItem item = value.itemAt(0);
     XdmAtomicValue atomic = (XdmAtomicValue) item;
     return Math.toIntExact(atomic.getLongValue());
   }
 
+  /**
+   * Extract a single string value from an XdmValue.
+   * @param value the XdmValue to extract from
+   * @return the string extracted
+   */
   public static String extractString(XdmValue value) {
     XdmItem item = value.itemAt(0);
     XdmAtomicValue atomic = (XdmAtomicValue) item;
     return atomic.getStringValue();
   }
 
+  /**
+   * Generate a RequestedDoiVersion from the arguments passed.
+   * @param arguments an XdmValue array. The first entry is ignored,
+   *   the second is the doi string, and the third is the ingestion
+   *   number
+   * @return the RequestedDoiVersion generated from the arguments
+   */
   public RequestedDoiVersion getDoiFromArguments(XdmValue[] arguments) throws SaxonApiException {
     String doi = extractString(arguments[1]);
     int ingestionNumber = extractInt(arguments[2]);
@@ -107,6 +124,12 @@ public class DataUriEncodeFunction implements ExtensionFunction {
     return "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(body);
   }
 
+  /**
+   * Encode a HttpEntity as a data url, or return empty if there was an IOException.
+   * @param entity  the HttpEntity to encode; will use the Content-Type and the body
+   * @return either a string representing the base-64 encoded data
+   *   url, or empty if there was an error
+   */
   public static Optional<String> encodeAsDataUrl(HttpEntity entity) {
     ContentType contentType = ContentType.get(entity);
     if (contentType == null) {

--- a/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
+++ b/src/main/java/org/ambraproject/wombat/service/DataUriEncodeFunction.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2018 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.service;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import net.sf.saxon.s9api.ExtensionFunction;
+import net.sf.saxon.s9api.ItemType;
+import net.sf.saxon.s9api.OccurrenceIndicator;
+import net.sf.saxon.s9api.QName;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.SequenceType;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmValue;
+import org.ambraproject.wombat.config.site.Site;
+import org.ambraproject.wombat.identity.AssetPointer;
+import org.ambraproject.wombat.identity.RequestedDoiVersion;
+import org.ambraproject.wombat.service.remote.ContentKey;
+import org.ambraproject.wombat.service.remote.CorpusContentApi;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.ContentType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataUriEncodeFunction implements ExtensionFunction {
+  static enum AssetUrlStyle {
+    FIGURE_IMAGE("figureImage", "size", new String[]{"figure", "table", "standaloneStrikingImage"}),
+    ASSET_FILE("assetFile", "type", new String[]{"article", "supplementaryMaterial", "graphic"});
+
+    private final String handlerName;
+    private final String typeParameterName;
+    private final ImmutableSet<String> itemTypes;
+
+    private AssetUrlStyle(String handlerName, String typeParameterName, String[] itemTypes) {
+      this.handlerName = Objects.requireNonNull(handlerName);
+      this.typeParameterName = Objects.requireNonNull(typeParameterName);
+      this.itemTypes = ImmutableSet.copyOf(itemTypes);
+    }
+
+    private static final ImmutableMap<String, AssetUrlStyle> BY_ITEM_TYPE =
+        EnumSet.allOf(AssetUrlStyle.class).stream()
+            .flatMap((AssetUrlStyle s) -> s.itemTypes.stream()
+                .map((String itemType) -> Maps.immutableEntry(itemType, s)))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    static AssetUrlStyle findByItemType(String itemType) {
+      AssetUrlStyle style = BY_ITEM_TYPE.get(itemType);
+      if (style == null) throw new IllegalArgumentException("Unrecognized: " + itemType);
+      return style;
+    }
+  }
+
+  @Autowired
+  private CorpusContentApi corpusContentApi;
+
+  @Autowired
+  private ArticleResolutionService articleResolutionService;
+
+  @Autowired
+  private ArticleService articleService;
+
+  @Override
+  public QName getName() {
+    return new QName("http://www.ambraproject.org/xslt/", "embed-data-uri");
+  }
+
+  @Override
+  public SequenceType getResultType() {
+    return SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE);
+  }
+
+  @Override
+  public SequenceType[] getArgumentTypes() {
+    return new SequenceType[] {
+      SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE),
+      SequenceType.makeSequenceType(ItemType.STRING, OccurrenceIndicator.ONE)
+    };
+  }
+
+  @Override
+  public XdmValue call(XdmValue[] arguments) throws SaxonApiException {
+    XdmValue fallback = new XdmAtomicValue("article/file?type=thumbnail&id=" + arguments[0].toString() + arguments[0].toString());
+
+    try {
+      String doi = arguments[0].toString();
+      String version = arguments[1].toString();
+
+      AssetUrlStyle requestedStyle = AssetUrlStyle.ASSET_FILE;
+      Site site;
+      String fileType = "thumbnail";
+      Boolean isDownload = true;
+
+      RequestedDoiVersion id = RequestedDoiVersion.of(doi);
+      AssetPointer asset = articleResolutionService.toParentIngestion(id);
+      String type = "thumbnail";
+      Map<String, ?> itemMetadata = articleService.getItemMetadata(asset);
+      String itemType = (String) itemMetadata.get("itemType");
+      AssetUrlStyle itemStyle = AssetUrlStyle.findByItemType(itemType);
+
+      Map<String, ?> files = (Map<String, ?>) itemMetadata.get("files");
+      Map<String, ?> fileRepoKey = (Map<String, ?>) files.get(fileType);
+      ContentKey contentKey = createKey(fileRepoKey);
+      try (CloseableHttpResponse responseFromApi = corpusContentApi.request(contentKey, ImmutableList.of())) {
+        HttpEntity entity = responseFromApi.getEntity();
+        ContentType contentType = null;
+        if (entity != null) { contentType = ContentType.get(entity); }
+        if (contentType == null) {
+          return fallback;
+        } else {
+          byte[] body = IOUtils.toByteArray(responseFromApi.getEntity().getContent());
+          String dataUri = "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(body);
+          return new XdmAtomicValue(dataUri);
+        }
+      }
+    } catch (Exception ex) {
+      return fallback;
+    }
+  }
+
+  private static ContentKey createKey(Map<String, ?> fileRepoKey) {
+    String key = (String) fileRepoKey.get("crepoKey");
+    UUID uuid = UUID.fromString((String) fileRepoKey.get("crepoUuid"));
+    ContentKey contentKey = ContentKey.createForUuid(key, uuid);
+    if (fileRepoKey.get("bucketName") != null) {
+      contentKey.setBucketName(fileRepoKey.get("bucketName").toString());
+    }
+    return contentKey;
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/service/remote/AbstractContentApi.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/AbstractContentApi.java
@@ -22,10 +22,12 @@
 
 package org.ambraproject.wombat.service.remote;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import org.ambraproject.wombat.util.CacheKey;
 import org.ambraproject.wombat.util.UrlParamBuilder;
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +40,7 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class AbstractContentApi implements ContentApi {
 
@@ -149,4 +152,12 @@ public abstract class AbstractContentApi implements ContentApi {
         (Reader stream) -> gson.fromJson(stream, Map.class));
   }
 
+  @Override
+  public Optional<CloseableHttpResponse> optionalRequest(ContentKey contentKey) {
+    try {
+      return Optional.ofNullable(request(contentKey, ImmutableList.of()));
+    } catch (IOException ex) {
+      return Optional.empty();
+    }
+  }
 }

--- a/src/main/java/org/ambraproject/wombat/service/remote/ContentApi.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/ContentApi.java
@@ -29,6 +29,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 public interface ContentApi {
 
@@ -42,6 +43,13 @@ public interface ContentApi {
    */
   public abstract CloseableHttpResponse request(ContentKey key, Collection<? extends Header> headers)
       throws IOException;
+
+  /**
+   * Requests a file from the content repository. Returns empty optional if an IOException was encountered.
+   * @param key the content repo key
+   * @return either the response from the content repo or empty if there was an error
+   */
+  public abstract Optional<CloseableHttpResponse> optionalRequest(ContentKey key);
 
   public abstract Map<String, Object> requestMetadata(CacheKey cacheKey, ContentKey key) throws IOException;
 

--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -57,6 +57,7 @@
                  used to provide DOIs and author/title overrides for reference links -->
   <xsl:param name="refs"/>
 
+  <xsl:param name="ingestionNumber"/>
   <xsl:param name="versionLinkParameter"/>
 
   <!-- ============================================================= -->
@@ -1609,7 +1610,8 @@
           <xsl:value-of select="@xlink:href"/>
         </xsl:variable>
         <xsl:attribute name="src">
-          <xsl:value-of select="ambra:embed-data-uri($graphicDOI, $versionLinkParameter)"/>
+          <xsl:value-of select="ambra:embed-data-uri($graphicDOI, $ingestionNumber,
+                                                     concat('article/file?type=thumbnail&amp;id=', $graphicDOI, $versionLink)"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:attribute name="class">

--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -35,6 +35,7 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:aml="http://topazproject.org/aml/"
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:ambra="http://www.ambraproject.org/xslt/"
                 exclude-result-prefixes="util xsl xlink mml xs aml dc">
 
   <!-- 1/4/12: Ambra-specific instruction. import nlm -->
@@ -1608,7 +1609,7 @@
           <xsl:value-of select="@xlink:href"/>
         </xsl:variable>
         <xsl:attribute name="src">
-          <xsl:value-of select="concat('article/file?type=thumbnail&amp;id=',$graphicDOI,$versionLinkParameter)"/><!-- TODO: Avoid relative path -->
+          <xsl:value-of select="ambra:embed-data-uri($graphicDOI, $versionLinkParameter)"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:attribute name="class">

--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -1610,7 +1610,7 @@
           <xsl:value-of select="@xlink:href"/>
         </xsl:variable>
         <xsl:attribute name="src">
-          <xsl:value-of select="ambra:embed-data-uri($graphicDOI, $ingestionNumber,
+          <xsl:value-of select="ambra:embed-data-url($graphicDOI, $ingestionNumber,
                                                      concat('article/file?type=thumbnail&amp;id=', $graphicDOI, $versionLink)"/>
         </xsl:attribute>
       </xsl:if>

--- a/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
@@ -52,6 +52,7 @@
   <!-- Ambra-specific global param (pub config, passed into stylesheet from elsewhere in the pipeline) -->
   <xsl:param name="pubAppContext"/>
 
+  <xsl:param name="ingestionNumber"/>
   <xsl:param name="versionLinkParameter"/>
 
   <!-- ============================================================= -->
@@ -1361,7 +1362,8 @@
           <xsl:value-of select="@xlink:href"/>
         </xsl:variable>
         <xsl:attribute name="src">
-          <xsl:value-of select="concat('article/file?type=thumbnail&amp;id=', $graphicDOI,$versionLinkParameter)"/><!-- TODO: Avoid relative path -->
+          <xsl:value-of select="ambra:embed-data-url($graphicDOI, $ingestionNumber,
+                                                     concat('article/file?type=thumbnail&amp;id=', $graphicDOI, $versionLink)"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:attribute name="class">

--- a/src/test/java/org/ambraproject/wombat/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/ArticleServiceImplTest.java
@@ -1,33 +1,110 @@
 package org.ambraproject.wombat.service;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
+import org.ambraproject.wombat.identity.ArticlePointer;
+import org.ambraproject.wombat.identity.AssetPointer;
+import org.ambraproject.wombat.identity.RequestedDoiVersion;
+import org.ambraproject.wombat.service.remote.ApiAddress;
+import org.ambraproject.wombat.service.remote.ArticleApi;
 import org.ambraproject.wombat.service.remote.ContentKey;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class ArticleServiceImplTest {
+  @Mock
+  RequestedDoiVersion doi;
+
+  @Mock
+  AssetPointer assetPointer;
+
+  @Mock
+  ArticleApi articleApi;
+
+  @Mock
+  ArticlePointer assetParent;
+
+  @Mock
+  ApiAddress.Builder builder;
+
+  @Mock
+  ApiAddress itemAddress;
+
+  @Mock
+  ArticleResolutionService articleResolutionService;
+
   @InjectMocks
-  private ArticleServiceImpl articleService;
+  ArticleServiceImpl articleService;
 
   @BeforeMethod
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }
 
+  String doiString = "10.9999/abc";
+  UUID crepoUuid = UUID.randomUUID();
+  String crepoKey = "key";
+  ContentKey contentKey = ContentKey.createForUuid(crepoKey, crepoUuid);
+
+  private Map<String, Map<String, Map<String, Map<String, Map<String, String>>>>>
+    createItem(String kind) {
+    /* lol */
+    Map<String, Map<String, Map<String, Map<String, Map<String, String>>>>> retval = new HashMap<>();
+    Map<String, Map<String, Map<String, Map<String, String>>>> items = new HashMap<>();
+    Map<String, Map<String, Map<String, String>>> item = new HashMap<>();
+    Map<String, Map<String, String>> files = new HashMap<>();
+    Map<String, String> file = new HashMap<>();
+    retval.put("items", items);
+    items.put(doiString, item);
+    item.put("files", files);
+    files.put(kind, file);
+    file.put("crepoKey", crepoKey);
+    file.put("crepoUuid", crepoUuid.toString());
+    return retval;
+  }
+  
+  
   @Test
   public void testCreateKeyFromMap() {
-    Map<String, String> fileRepoMap = new HashMap<>();
-    fileRepoMap.put("crepoKey", "foo");
-    UUID uuid =  UUID.randomUUID();
-    fileRepoMap.put("crepoUuid", uuid.toString());
-    ContentKey key = articleService.createKeyFromMap(fileRepoMap);
-    assertEquals(String.format("[key: foo, uuid: %s]", uuid), key.toString());
+    String kind = "foo";
+    Map<String, String> fileRepoMap =
+      createItem(kind).get("items").get(doiString).get("files").get(kind);
+    assertEquals(contentKey, articleService.createKeyFromMap(fileRepoMap));
+  }
+
+  @Test
+  public void testGetThumbnailKey() throws IOException {
+    when(doi.getDoi()).thenReturn(doiString);
+    when(articleResolutionService.toParentIngestion(doi)).thenReturn(assetPointer);
+    when(assetPointer.getParentArticle()).thenReturn(assetParent);
+    when(assetPointer.getAssetDoi()).thenReturn(doiString);
+    when(assetParent.asApiAddress()).thenReturn(builder);
+    when(builder.addToken("items")).thenReturn(builder);
+    when(builder.build()).thenReturn(itemAddress);
+    when(articleApi.requestObject(itemAddress, Map.class)).thenReturn(createItem("thumbnail"));
+    assertEquals(Optional.of(contentKey), articleService.getThumbnailKey(doi));
+  }
+
+  @Test
+  public void testGetThumbnailKeyEmpty() throws IOException {
+    when(doi.getDoi()).thenReturn(doiString);
+    when(articleResolutionService.toParentIngestion(doi)).thenReturn(assetPointer);
+    when(assetPointer.getParentArticle()).thenReturn(assetParent);
+    when(assetPointer.getAssetDoi()).thenReturn(doiString);
+    when(assetParent.asApiAddress()).thenReturn(builder);
+    when(builder.addToken("items")).thenReturn(builder);
+    when(builder.build()).thenReturn(itemAddress);
+    when(articleApi.requestObject(itemAddress, Map.class)).thenReturn(createItem("notThumbnail"));
+    assertEquals(Optional.empty(), articleService.getThumbnailKey(doi));
   }
 }

--- a/src/test/java/org/ambraproject/wombat/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/ArticleServiceImplTest.java
@@ -1,0 +1,33 @@
+package org.ambraproject.wombat.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.ambraproject.wombat.service.remote.ContentKey;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ArticleServiceImplTest {
+  @InjectMocks
+  private ArticleServiceImpl articleService;
+
+  @BeforeMethod
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testCreateKeyFromMap() {
+    Map<String, String> fileRepoMap = new HashMap<>();
+    fileRepoMap.put("crepoKey", "foo");
+    UUID uuid =  UUID.randomUUID();
+    fileRepoMap.put("crepoUuid", uuid.toString());
+    ContentKey key = articleService.createKeyFromMap(fileRepoMap);
+    assertEquals(String.format("[key: foo, uuid: %s]", uuid), key.toString());
+  }
+}

--- a/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
@@ -1,0 +1,30 @@
+package org.ambraproject.wombat.service;
+
+import org.testng.annotations.Test;
+
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmItem;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataUriEncodeFunctionTest {
+  List<XdmItem> emptyList = new ArrayList<XdmItem>();
+  XdmItem trueXdm = new XdmAtomicValue(true);
+  XdmItem oneXdm = new XdmAtomicValue(1);
+  XdmItem helloXdm = new XdmAtomicValue("hello");
+  
+  @Test
+  public void testExtractInt() throws SaxonApiException {
+    assertEquals(0, DataUriEncodeFunction.extractInt(trueXdm));
+    assertEquals(1, DataUriEncodeFunction.extractInt(oneXdm));
+  }
+
+  @Test
+  public void testExtractString() throws SaxonApiException {
+    assertEquals("hello", DataUriEncodeFunction.extractString(helloXdm));
+  }
+}

--- a/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
@@ -74,7 +74,7 @@ public class DataUriEncodeFunctionTest {
   public void testEncodeAsDataUri() throws IOException {
     assertEquals(Optional.empty(), DataUriEncodeFunction.encodeAsDataUrl(null));
 
-    InputStream stubInputStream =  IOUtils.toInputStream("bar", "UTF-8"); // base64: Zm9v
+    InputStream stubInputStream =  IOUtils.toInputStream("bar", "UTF-8"); // base64: YmFy
     HttpEntity entity = mock(HttpEntity.class);
     Header header = mock(Header.class);
     HeaderElement element = mock(HeaderElement.class);

--- a/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
@@ -1,13 +1,11 @@
 package org.ambraproject.wombat.service;
 
 import org.ambraproject.wombat.identity.RequestedDoiVersion;
-import org.ambraproject.wombat.service.remote.ContentKey;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
-import org.apache.http.entity.ContentType;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -24,11 +22,8 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -86,15 +81,5 @@ public class DataUriEncodeFunctionTest {
     
     assertEquals(Optional.of("data:image/x-foo;base64,YmFy"),
                  DataUriEncodeFunction.encodeAsDataUrl(entity));
-  }
-
-  @Test
-  public void testCreateKeyFromMap() {
-    Map<String, String> fileRepoMap = new HashMap<>();
-    fileRepoMap.put("crepoKey", "foo");
-    UUID uuid =  UUID.randomUUID();
-    fileRepoMap.put("crepoUuid", uuid.toString());
-    ContentKey key = DataUriEncodeFunction.createKeyFromMap(fileRepoMap);
-    assertEquals(String.format("[key: foo, uuid: %s]", uuid), key.toString());
   }
 }

--- a/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
@@ -1,10 +1,16 @@
 package org.ambraproject.wombat.service;
 
+import org.ambraproject.wombat.identity.RequestedDoiVersion;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import net.sf.saxon.s9api.ItemType;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmAtomicValue;
 import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XdmValue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -16,6 +22,15 @@ public class DataUriEncodeFunctionTest {
   XdmItem trueXdm = new XdmAtomicValue(true);
   XdmItem oneXdm = new XdmAtomicValue(1);
   XdmItem helloXdm = new XdmAtomicValue("hello");
+
+
+  @InjectMocks
+  DataUriEncodeFunction dataUriEncodeFunction;
+
+  @BeforeMethod
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+  }
   
   @Test
   public void testExtractInt() throws SaxonApiException {
@@ -26,5 +41,16 @@ public class DataUriEncodeFunctionTest {
   @Test
   public void testExtractString() throws SaxonApiException {
     assertEquals("hello", DataUriEncodeFunction.extractString(helloXdm));
+  }
+
+  @Test
+  public void testGetDoiFromArguments() throws SaxonApiException {
+    String doiString = "10.9999/1";
+    XdmValue doiXdm = new XdmAtomicValue(doiString, ItemType.STRING);
+    int ingestionNumber = 1;
+    XdmValue ingestionNumberXdm = new XdmAtomicValue(ingestionNumber);
+
+    assertEquals(RequestedDoiVersion.ofIngestion(doiString, ingestionNumber),
+                 dataUriEncodeFunction.getDoiFromArguments(new XdmValue[]{helloXdm, doiXdm, ingestionNumberXdm}));
   }
 }

--- a/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/DataUriEncodeFunctionTest.java
@@ -1,6 +1,7 @@
 package org.ambraproject.wombat.service;
 
 import org.ambraproject.wombat.identity.RequestedDoiVersion;
+import org.ambraproject.wombat.service.remote.ContentKey;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
@@ -23,8 +24,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -82,5 +86,15 @@ public class DataUriEncodeFunctionTest {
     
     assertEquals(Optional.of("data:image/x-foo;base64,YmFy"),
                  DataUriEncodeFunction.encodeAsDataUrl(entity));
+  }
+
+  @Test
+  public void testCreateKeyFromMap() {
+    Map<String, String> fileRepoMap = new HashMap<>();
+    fileRepoMap.put("crepoKey", "foo");
+    UUID uuid =  UUID.randomUUID();
+    fileRepoMap.put("crepoUuid", uuid.toString());
+    ContentKey key = DataUriEncodeFunction.createKeyFromMap(fileRepoMap);
+    assertEquals(String.format("[key: foo, uuid: %s]", uuid), key.toString());
   }
 }

--- a/src/test/java/org/ambraproject/wombat/service/TestArticleServiceImpl.java
+++ b/src/test/java/org/ambraproject/wombat/service/TestArticleServiceImpl.java
@@ -33,6 +33,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * used to return article metadata from json files during tests of article controller functionality
@@ -67,6 +68,11 @@ public class TestArticleServiceImpl implements ArticleService {
 
   @Override
   public Map<String, ?> getItemFiles(AssetPointer assetId) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Optional<ContentKey> getThumbnailKey(RequestedDoiVersion doi) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
:warning: WORK IN PROGRESS - don't merge

https://jira.plos.org/jira/browse/AMBR-218

An implementation to encode math images as data-uris to reduce the large number (> 100) of requests for math-heavy articles.

The implementation is done as a Saxon function that is used in the stylesheet (see https://github.com/PLOS/wombat/pull/1464/files#diff-43df5e74de352e626062f5ba9acbbf2bR1613)
This function either returns a data-url if it can successfully download and encode the image thumbnail, or it returns a fallback value.
