### PR TITLE
Bump version to 3.7.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>wombat</artifactId>
   <name>wombat</name>
   <packaging>war</packaging>
-  <version>3.7.1</version>
+  <version>3.7.2-SNAPSHOT</version>
   <url>https://github.com/PLOS/wombat</url>
   <scm>
     <connection>scm:git:git@github.com:PLOS/wombat.git</connection>


### PR DESCRIPTION
The `develop` branch should always have a `SNAPSHOT` version.