### PR TITLE
peerReview is null when there are no peer review items

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
@@ -174,7 +174,7 @@ public class ArticleMetadata {
 
     model.addAttribute("revisionMenu", getRevisionMenu());
 
-    model.addAttribute("peerReview", getPeerReview().toString());
+    model.addAttribute("peerReview", getPeerReview());
     return this;
   }
 
@@ -227,12 +227,16 @@ public class ArticleMetadata {
   /**
    * Get the articleItems that represent peer review decisions and responses.
    */
-  List<Map<String,?>> getPeerReview() {
-    List tprItems = itemTable.values().stream()
+  String getPeerReview() {
+    List peerReviewItems = itemTable.values().stream()
         .filter(itemObj -> ((Map<String, ?>) itemObj).get("itemType").equals("reviewLetter"))
         .collect(Collectors.toList());
 
-    return tprItems;
+    if (peerReviewItems == null || peerReviewItems.isEmpty()) {
+      return null;
+    }
+
+    return peerReviewItems.toString();
   }
 
   /**

--- a/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
@@ -25,7 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -64,7 +66,7 @@ public class ArticleMetadataTest extends AbstractTestNGSpringContextTests {
     doReturn(null).when(articleMetadata).getCategoryTerms();
     doReturn(null).when(articleMetadata).getRelatedArticles();
     doReturn(null).when(articleMetadata).getRevisionMenu();
-    doReturn(new ArrayList()).when(articleMetadata).getPeerReview();
+    doReturn(null).when(articleMetadata).getPeerReview();
     doNothing().when(articleMetadata).populateAuthors(any());
 
     articleMetadata.populate(mock(HttpServletRequest.class), mock(Model.class));
@@ -165,5 +167,67 @@ public class ArticleMetadataTest extends AbstractTestNGSpringContextTests {
     List<Map<String, ?>> expectedFigureView = new ArrayList<>();
     expectedFigureView.add(expected);
     assertEquals(articleMetadata.getFigureView(), expectedFigureView);
+  }
+
+  @Test
+  public void testGetPeerReview() {
+    Map<String, String> asset = new HashMap<>();
+    asset.put("doi", "fakeDoi");
+    List<Map<String, String>> assets = new ArrayList<>();
+    assets.add(asset);
+    HashMap<String, List<Map<String, String>>> ingestionMetadata = new HashMap<>();
+    ingestionMetadata.put("assetsLinkedFromManuscript", assets);
+
+    Map<String, String> item = new HashMap<>();
+    item.put("itemType", "reviewLetter");
+    Map<String, Map<String, String>> itemTable = new HashMap<>();
+    itemTable.put("fakeDoi", item);
+
+    Theme theme = mock(Theme.class);
+    HashMap<String, Object> journalAttrs = new HashMap<>();
+    journalAttrs.put("journalKey", "fakeKey");
+    journalAttrs.put("journalName", "fakeName");
+    when(theme.getConfigMap(any())).thenReturn(journalAttrs);
+
+    Site site = new Site("foo", theme, mock(SiteRequestScheme.class), "foo");
+    ArticleMetadata articleMetadata = articleMetadataFactory.newInstance(site,
+        mock(RequestedDoiVersion.class),
+        mock(ArticlePointer.class),
+        ingestionMetadata,
+        itemTable,
+        new HashMap());
+
+    assertNotNull(articleMetadata.getPeerReview());
+  }
+
+  @Test
+  public void testGetPeerReviewReturnsNullWhenNoPeerReviewItems() {
+    Map<String, String> asset = new HashMap<>();
+    asset.put("doi", "fakeDoi");
+    List<Map<String, String>> assets = new ArrayList<>();
+    assets.add(asset);
+    HashMap<String, List<Map<String, String>>> ingestionMetadata = new HashMap<>();
+    ingestionMetadata.put("assetsLinkedFromManuscript", assets);
+
+    Map<String, String> item = new HashMap<>();
+    item.put("itemType", "figure");
+    Map<String, Map<String, String>> itemTable = new HashMap<>();
+    itemTable.put("fakeDoi", item);
+
+    Theme theme = mock(Theme.class);
+    HashMap<String, Object> journalAttrs = new HashMap<>();
+    journalAttrs.put("journalKey", "fakeKey");
+    journalAttrs.put("journalName", "fakeName");
+    when(theme.getConfigMap(any())).thenReturn(journalAttrs);
+
+    Site site = new Site("foo", theme, mock(SiteRequestScheme.class), "foo");
+    ArticleMetadata articleMetadata = articleMetadataFactory.newInstance(site,
+        mock(RequestedDoiVersion.class),
+        mock(ArticlePointer.class),
+        ingestionMetadata,
+        itemTable,
+        new HashMap());
+
+    assertNull(articleMetadata.getPeerReview());
   }
 }


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-631

*Related PRs:* 
https://github.com/PLOS/wombat/pull/1471

## What this PR does:

PeerReview tab was showing for all articles.  This adds tests to confirm that TPR will be null when no peer review items are present.  

## Developer Notes

Returning null is consistent with the rest of the doPopulate() method.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Ticket AC is updated with any decisions made in comments or side conversations.
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.
- [x] All PRs are created and linked for work I have done against other projects as part of this ticket.
- [x] Intergration Tests have been addressed.  QA has been notified of the feature and a ticket has been created for that work, or integration tests have been updated. 
- [x] There are unit tests sufficient for both positive and negative test cases, test coverage has not decreased as part of this work. 
- [x] Any necessary documentation in confluence or READMEs is updated.

If I used outside libraries:
~~- [ ] Confirmed unique - we aren't using something similar elsewhere~~
~~- [ ] License comports with our licensing (MIT preferable)~~

If I modified any environment variables:
~~- [ ] Pull requests are created to change the files in molten or in SALT-formulas.~~

If I made any database changes:
~~- [ ] DB migration scripts are created and this detail is added to testing notes in the ticket.~~

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).
- [ ] The code adheres to the values and guidelines of the project. (link here)
- [ ] Security vulnerabilities have been addressed.

## Project or Language Specific Tasks ###
