### PR TITLE
Remove impossible tasks

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,5 @@ If I made any database changes:
 # Code Reviewer Tasks
 - [ ] I read through the JIRA ticket's AC before doing the rest of the review.
 - [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).
-- [ ] The code adheres to the values and guidelines of the project. (link here)
-- [ ] Security vulnerabilities have been addressed.
 
 ## Project or Language Specific Tasks ###


### PR DESCRIPTION
Remove two checkboxes in the pull request template that were so vague as to be impossible to complete.

## What this PR does:

Remove 2 checkboxes for the reviewer in the pull request template that were impossible to do, because they were so vague or had a broken link.

# Code Author Tasks:

> This list should be finished before code review:
- [X] Any necessary documentation in confluence or READMEs is updated.

# Code Reviewer Tasks
- [x] Made sense to me.