### PR TITLE
Ambr 822 part 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,12 +387,14 @@
               <groupId>org.ambraproject</groupId>
               <artifactId>wombat</artifactId>
               <type>war</type>
+              <location>${project.build.directory}/${project.build.finalName}</location>
               <properties>
                 <context>/</context>
               </properties>
             </deployable>
           </deployables>
           <configuration>
+            <type>standalone</type>
             <properties>
               <cargo.servlet.port>8080</cargo.servlet.port>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
           <container>
             <containerId>tomcat8x</containerId>
             <zipUrlInstaller>
-              <url>http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.5.37/tomcat-8.5.37.zip</url>
+              <url>http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.0.32/tomcat-8.0.32.zip</url>
             </zipUrlInstaller>
             <systemProperties>
               <java.util.logging.manager>org.apache.juli.ClassLoaderLogManager</java.util.logging.manager>

--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@
         <version>0.3.0</version>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>install</phase>
             <goals>
               <goal>apt-repo</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
           </deployables>
           <configuration>
             <properties>
-              <cargo.servlet.port>8082</cargo.servlet.port>
+              <cargo.servlet.port>8080</cargo.servlet.port>
             </properties>
           </configuration>
         </configuration>

--- a/src/deb/control/config
+++ b/src/deb/control/config
@@ -13,7 +13,6 @@ case "$1" in
 
 # parameters provided by the debconf wizard
 $INPUT/wombat_port || true
-$INPUT/control_port || true
 $INPUT/tomcat_admin_user || true
 $INPUT/tomcat_admin_password || true
 

--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -49,7 +49,6 @@ case "$1" in
   # Fetching configuration from debconf
 
   $GET/wombat_port && export WOMBAT_PORT=$RET
-  $GET/control_port && export CONTROL_PORT=$RET
   $GET/tomcat_admin_user && export TOMCAT_ADMIN_USER=$RET
   $GET/tomcat_admin_password && export TOMCAT_ADMIN_PASSWORD=$RET
 

--- a/src/deb/control/templates
+++ b/src/deb/control/templates
@@ -12,8 +12,3 @@ Template: [[artifactId]]/wombat_port
 Type: string
 Default: 8015
 Description: The HTTP port you would like Wombat to be accessible from
-
-Template: [[artifactId]]/control_port
-Type: string
-Default: 8014
-Description: The TCP port to use for Tomcat shutdown control port

--- a/src/deb/tomcat8/conf/server.template.xml
+++ b/src/deb/tomcat8/conf/server.template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Server port="${CONTROL_PORT}" shutdown="SHUTDOWN">
+<Server port="-1" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />

--- a/src/deb/tomcat8/conf/server.template.xml
+++ b/src/deb/tomcat8/conf/server.template.xml
@@ -6,7 +6,7 @@
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.JmxRemoteLifecycleListener"
-            rmiRegistryPortPlatform="21212" rmiServerPortPlatform="21213"
+            rmiRegistryPortPlatform="0" rmiServerPortPlatform="0"
             useLocalPorts="true" />
   <GlobalNamingResources>
     <Resource name="UserDatabase" auth="Container"


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-822

## What this PR does:

Cleans up a few issues with AMBR-822:
- Sets cargo to use the tomcat we have installed on our current boxes, 8.0.32
- Uses 8080 as the port that tomcat listens on when running locally
- Disables the shutdown port in tomcat, which is not needed on linux
- Uses a random port for JMX, preventing possible port conflicts
- Only installs deb package in `/var/tmp/apt` in the `install` maven goal

# Code Reviewer Tasks
- [x] I read through the JIRA ticket's AC before doing the rest of the review.
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).
