### PR TITLE
AMBR-822 explicitly use saxon transformer

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/PeerReviewServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/PeerReviewServiceImpl.java
@@ -75,7 +75,7 @@ public class PeerReviewServiceImpl implements PeerReviewService {
 
     StringWriter htmlWriter = new StringWriter();
     try {
-      Transformer transformer = TransformerFactory.newInstance().newTransformer(xslSource);
+      Transformer transformer = SiteTransformerFactory.newTransformerFactory().newTransformer(xslSource);
       transformer.transform(xmlSource, new StreamResult(htmlWriter));
     } catch (TransformerException e) {
       throw new RuntimeException(e);

--- a/src/main/java/org/ambraproject/wombat/service/SiteTransformerFactory.java
+++ b/src/main/java/org/ambraproject/wombat/service/SiteTransformerFactory.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class SiteTransformerFactory {
 
-  private static TransformerFactory newTransformerFactory() {
+  static TransformerFactory newTransformerFactory() {
     // This implementation is required for XSLT features, so just hard-code it here
     // Preferred over TransformerFactory.newInstance because Java system properties can burn in hell
     return new net.sf.saxon.TransformerFactoryImpl();


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/-AMBR-822

## What this PR does:
Explicity uses an XML transformer that supports XSL transforms.  We were using a default transformer before this change, but we found that on tomcat 8 with the cargo runner the default transformer does not seem to support XSL.  As a result the Peer Review content is a wall unformatted text.

## Developer Notes
This issue is not present in the [dev environment](https://journals-dev.plos.org/plosone/article/peerReview?id=10.1371/journal.pone.0207232)
Noting that we still don't know what exactly would need to be changed in the local cargo-run environment to have parity with dev in regards to the default transformer. We have chosen not to prioritize further investigation.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Ticket AC is updated with any decisions made in comments or side conversations.
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.

# Code Reviewer Tasks
- [x] I read through the JIRA ticket's AC before doing the rest of the review.
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
