### PR TITLE
rename and extract methods for clarity

### DIFF
--- a/src/test/java/org/ambraproject/wombat/controller/ArticleControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleControllerTest.java
@@ -38,13 +38,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.ui.Model;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -175,13 +173,13 @@ public class ArticleControllerTest extends ControllerTest {
         Reference.build().setTitle("Reference title").setPublisherName("Publisher Name")
             .setAuthors(ImmutableList.of()).setCollabAuthors(ImmutableList.of()).build();
     final ImmutableList<Reference> expectedReferences = ImmutableList.of(reference);
-    final ArticleController.XmlContent expectedXmlContent =
-        new ArticleController.XmlContent(expectedHtml, expectedReferences);
+    final ArticleController.HtmlWithReferences expectedHtmlWithReferences =
+        new ArticleController.HtmlWithReferences(expectedHtml, expectedReferences);
 
     final CorpusContentApi mockCorpusContentApi =
         applicationContext.getBean(CorpusContentApi.class);
     when(mockCorpusContentApi.readManuscript(any(), any(), any(), any()))
-        .thenReturn(expectedXmlContent);
+        .thenReturn(expectedHtmlWithReferences);
 
     final String expectedViewName = NOSPACE_JOINER.join(DESKTOP_PLOS_ONE, "/ftl/article/article");
     final String requestUri = NOSPACE_JOINER.join("/article?id=", EXPECTED_DOI);


### PR DESCRIPTION
## What this PR does:
Extracts and renames some methods to clarify what the article controller is doing when it gets the article HTML. 

## Developer Notes

This is a straight refactor.  Does it make what is happeneing clearer to you?

# Code Reviewer Tasks
- [ ] I consider this an improvement
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).