### PR TITLE
AMBR-886 Fix issue with upgrade to tomcat8

### DIFF
--- a/src/main/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirective.java
+++ b/src/main/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirective.java
@@ -39,9 +39,10 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.io.IOException;
+import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -96,15 +97,16 @@ public class ReplaceParametersDirective implements TemplateDirectiveModel {
 
     // The map is passed in as a Map<String, String[]>, but Freemarker doesn't support generics
     // (and wraps the map in its own data structure).
-    Map map = parameterMap.toMap();
-    Iterator iter = map.entrySet().iterator();
-    while (iter.hasNext()) {
-      Map.Entry entry = (Map.Entry) iter.next();
-      String[] values = (String[]) entry.getValue();
-      for (String value : values) {
-        result.put((String) entry.getKey(), value);
-      }
-    }
+    
+    Map<String, Object> map = parameterMap.toMap();
+    map.forEach((key, values) -> {
+        if (values.getClass().isArray()) {
+          result.putAll(key, (Arrays.asList((String[]) values)));
+        } else {
+          result.putAll(key, (AbstractList<String>) values);
+        }
+      });
+          
 
     for (Map.Entry<String, Collection<TemplateModel>> replacementEntry : replacements.asMap().entrySet()) {
       Collection<String> replacementValues = Collections2.transform(replacementEntry.getValue(), Object::toString);

--- a/src/test/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirectiveTest.java
+++ b/src/test/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirectiveTest.java
@@ -31,7 +31,9 @@ import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateModel;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
@@ -39,7 +41,26 @@ import static org.testng.Assert.assertEquals;
 public class ReplaceParametersDirectiveTest {
 
   @Test
-  public void testReplaceParameters() throws Exception {
+  public void testReplaceParametersList() throws Exception {
+    Map<String, List<String>> parameters = new HashMap<>();
+    parameters.put("foo", Arrays.asList("fooValue"));
+    parameters.put("multiValuedParam", Arrays.asList("value1", "value2"));
+    parameters.put("emptyParam", Arrays.asList(""));
+    parameters.put("paramToReplace", Arrays.asList("oldValue"));
+    Multimap<String, TemplateModel> replacements = ImmutableMultimap.of("paramToReplace", new SimpleScalar("newValue"));
+
+    Multimap<String, String> actual = ReplaceParametersDirective.replaceParameters(new SimpleHash(parameters),
+        replacements);
+    ImmutableSetMultimap.Builder<String, String> expected = ImmutableSetMultimap.builder();
+    expected.put("foo", "fooValue")
+        .putAll("multiValuedParam", "value1", "value2")
+        .put("emptyParam", "")
+        .put("paramToReplace", "newValue");
+    assertEquals(actual, expected.build());
+  }
+
+  @Test
+  public void testReplaceParametersArray() throws Exception {
     Map<String, String[]> parameters = new HashMap<>();
     parameters.put("foo", new String[]{"fooValue"});
     parameters.put("multiValuedParam", new String[]{"value1", "value2"});
@@ -55,6 +76,5 @@ public class ReplaceParametersDirectiveTest {
         .put("emptyParam", "")
         .put("paramToReplace", "newValue");
     assertEquals(actual, expected.build());
-
   }
 }


### PR DESCRIPTION
In tomcat8, presumably because it supports a different version of the servlet spec, the type of the variables passed in to freemarker can be either a String[] or an AbstractList<String>.


*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-886

## What this PR does:

Handles both cases.

## Testing

To test, run:

`mvn cargo:run`

locally and visit:

http://localhost:8080/plosone/browse/geographical_locations?resultView=cover

If this works, you should not see an error.

You may need to configure your wombat properly. Check with me if your current config does not work.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Ticket AC is updated with any decisions made in comments or side conversations.
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.
- [x] All PRs are created and linked for work I have done against other projects as part of this ticket.
- [x] Intergration Tests have been addressed.  QA has been notified of the feature and a ticket has been created for that work, or integration tests have been updated. 
- [x] There are unit tests sufficient for both positive and negative test cases, test coverage has not decreased as part of this work. 
- [x] Any necessary documentation in confluence or READMEs is updated.

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
