### PR TITLE
AMBR-906 Use gzip compression in tomcat, not webapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,14 +245,6 @@
       <version>2.4.7</version>
     </dependency>
 
-    <!-- Needed for org.mortbay.servlet.GzipFilter in web.xml -->
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>6.1.25</version>
-    </dependency>
-
-
     <!-- "Optional" for string but because ned-client also requires it
          we need to use this version. -->
     <dependency>

--- a/src/deb/tomcat8/conf/server.template.xml
+++ b/src/deb/tomcat8/conf/server.template.xml
@@ -21,6 +21,7 @@
                enableLookups="false"
                maxParameterCount="5000"
                scheme="http" URIEncoding="UTF-8"
+               compression="true"
                minSpareThreads="50" maxThreads="1000"/>
     <Engine name="Catalina" defaultHost="localhost">
       <Realm className="org.apache.catalina.realm.LockOutRealm">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -31,27 +31,6 @@
     <param-value>/WEB-INF/spring/root-context.xml</param-value>
   </context-param>
 
-  <!-- gzip responses when appropriate.  -->
-  <filter>
-    <filter-name>gzip</filter-name>
-    <filter-class>org.mortbay.servlet.GzipFilter</filter-class>
-    <init-param>
-      <param-name>minGzipSize</param-name>
-      <param-value>100</param-value>
-    </init-param>
-    <init-param>
-      <param-name>mimeTypes</param-name>
-      <param-value>text/html,text/plain,text/css,text/javascript,application/xml,application/atom+xml</param-value>
-    </init-param>
-  </filter>
-
-  <filter-mapping>
-    <filter-name>gzip</filter-name>
-    <url-pattern>/*</url-pattern>
-    <dispatcher>REQUEST</dispatcher>
-    <dispatcher>FORWARD</dispatcher>
-  </filter-mapping>
-
   <filter>
     <filter-name>characterEncodingFilter</filter-name>
     <filter-class>


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-906

## What this PR does:

This work came out of work on https://jira.plos.org/jira/browse/AMBR-905

While doing that, I noticed that we were using a webapp filter to perform gzip compression on the fly. This can be handled in the tomcat container, which simplifies the application.

## Developer Notes

The configuration for which content is gzipped may have changed somewhat, but you can see that HTML is being compressed:

![image](https://user-images.githubusercontent.com/22718/54397667-7b485780-4674-11e9-8557-3618da3a8067.png)

js: 
![image](https://user-images.githubusercontent.com/22718/54397684-88fddd00-4674-11e9-91f7-855bd7608883.png)

and css:
![image](https://user-images.githubusercontent.com/22718/54397693-974bf900-4674-11e9-8689-47e9ecd3b73a.png)


Testing with `ab` (apache benchmark) shows similar performance as before:

Before change (and after warming up wombat):
```
👉 ab -l -c 10 -n 1000 -H "Accept-Encoding: gzip,deflate" http://journals.vagrant.local/
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking journals.vagrant.local (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        Apache/2.4.29
Server Hostname:        journals.vagrant.local
Server Port:            80

Document Path:          /
Document Length:        Variable

Concurrency Level:      10
Time taken for tests:   13.744 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      333845000 bytes
HTML transferred:       333344000 bytes
Requests per second:    72.76 [#/sec] (mean)
Time per request:       137.440 [ms] (mean)
Time per request:       13.744 [ms] (mean, across all concurrent requests)
Transfer rate:          23720.97 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   1.1      1      13
Processing:    44  136  54.1    128     394
Waiting:        8   21  16.8     16     168
Total:         44  137  54.2    129     394

Percentage of the requests served within a certain time (ms)
  50%    129
  66%    152
  75%    166
  80%    175
  90%    208
  95%    244
  98%    283
  99%    304
 100%    394 (longest request)

```

After change (and after warming up wombat):
```
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking journals.vagrant.local (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        Apache/2.4.29
Server Hostname:        journals.vagrant.local
Server Port:            80

Document Path:          /
Document Length:        Variable

Concurrency Level:      10
Time taken for tests:   10.488 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      334779903 bytes
HTML transferred:       334255903 bytes
Requests per second:    95.35 [#/sec] (mean)
Time per request:       104.876 [ms] (mean)
Time per request:       10.488 [ms] (mean, across all concurrent requests)
Transfer rate:          31173.20 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.9      1       9
Processing:    35  103  34.6    101     223
Waiting:        5   17   9.2     14      78
Total:         37  105  34.6    103     224

Percentage of the requests served within a certain time (ms)
  50%    103
  66%    117
  75%    128
  80%    133
  90%    151
  95%    165
  98%    184
  99%    200
 100%    224 (longest request)
```

# Code Author Tasks:

> This list should be finished before code review:
- [x] Ticket AC is updated with any decisions made in comments or side conversations.
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.
- [x] All PRs are created and linked for work I have done against other projects as part of this ticket.
- [x] Intergration Tests have been addressed.  QA has been notified of the feature and a ticket has been created for that work, or integration tests have been updated. 
- [x] There are unit tests sufficient for both positive and negative test cases, test coverage has not decreased as part of this work. 
- [x] Any necessary documentation in confluence or READMEs is updated.

# Code Reviewer Tasks
- [x] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
