### PR TITLE
AMBR-914 Bump frontend-maven-plugin version to 1.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,19 +496,16 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <!-- Use the latest released version:
-        https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
-        <version>1.3</version>
+        <version>1.7.5</version>
 
         <executions>
           <!-- Install Node and NPM -->
           <execution>
             <id>install node and npm</id>
+            <phase>prepare-package</phase>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <phase>generate-resources</phase>
-
             <configuration>
               <nodeVersion>v6.9.2</nodeVersion>
             </configuration>
@@ -516,6 +513,7 @@
           <!-- Install NPM Dependencies -->
           <execution>
             <id>npm install</id>
+            <phase>prepare-package</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -526,7 +524,7 @@
           <!-- Run gulp build -->
           <execution>
             <id>gulp build</id>
-            <phase>generate-resources</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>gulp</goal>
             </goals>


### PR DESCRIPTION
Also change to build in prepare-package phase, speeding up test builds.

*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-914

## What this PR does:

Increases the version of the plugin used to run gulp.

Also, changes the *phase* that these steps are run in to `prepare-package`. These files are not needed for the java tests, and this speeds up testing substantially by not building CSS files until they are needed.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.

# Code Reviewer Tasks
- [x] I read through the JIRA ticket's AC before doing the rest of the review.
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
