### PR TITLE
Switch to junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,9 +292,9 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>6.9.10</version>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/ambraproject/wombat/config/site/url/LinkTest.java
+++ b/src/test/java/org/ambraproject/wombat/config/site/url/LinkTest.java
@@ -22,17 +22,21 @@
 
 package org.ambraproject.wombat.config.site.url;
 
-import org.ambraproject.wombat.config.site.Site;
-import org.ambraproject.wombat.config.theme.StubTheme;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
+import org.ambraproject.wombat.config.site.Site;
+import org.ambraproject.wombat.config.theme.StubTheme;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.mock.web.MockHttpServletRequest;
 
+@RunWith(Parameterized.class)
 public class LinkTest {
 
   private static Site dummySite(String siteName, SiteRequestScheme scheme) {
@@ -52,8 +56,8 @@ public class LinkTest {
   private static final Site HOST_ONLY = dummySite("hostOnly",
       SiteRequestScheme.builder().specifyHost("hostOnly.example.com").build());
 
-  @DataProvider
-  public Object[][] toPathCases() {
+  @Parameters
+  public static List<Object[]> toPathCases() {
     List<Object[]> cases = new ArrayList<>();
 
     // Cases where the HttpServletRequest has no interesting properties
@@ -124,15 +128,23 @@ public class LinkTest {
     cases.add(new Object[]{Link.toLocalSite(HOST_ONLY).toPath("path"), proxiedPortReq, "/path"});
     cases.add(new Object[]{Link.toForeignSite(TOKEN_1, HOST_ONLY).toPath("path"), proxiedPortReq, "http://hostOnly.example.com:8082/path"});
 
-    return cases.toArray(new Object[0][]);
+    return cases;
   }
 
-  @Test(dataProvider = "toPathCases")
-  public void testToPath(Link link, MockHttpServletRequest request, String expectedPath) {
-    assertEquals(link.get(request), expectedPath);
+  @Parameter(0)
+  public Link link;
+
+  @Parameter(1)
+  public MockHttpServletRequest request;
+
+  @Parameter(2)
+  public String expectedPath;
+
+  public void testToPath() {
+    assertEquals(expectedPath, link.get(request));
   }
 
-  @Test(expectedExceptions = RuntimeException.class)
+  @Test(expected = RuntimeException.class)
   public void testInvalidToPathCase() {
     Link.toForeignSite(HOST_AND_TOKEN_1, TOKEN_1);
   }

--- a/src/test/java/org/ambraproject/wombat/config/theme/TestTheme.java
+++ b/src/test/java/org/ambraproject/wombat/config/theme/TestTheme.java
@@ -22,27 +22,36 @@
 
 package org.ambraproject.wombat.config.theme;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.config.site.SiteSet;
 import org.ambraproject.wombat.config.site.url.SiteRequestScheme;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Map;
-
-import static org.testng.Assert.assertEquals;
-
+@RunWith(Parameterized.class)
 public class TestTheme {
-
-  @DataProvider
-  public Object[][] booleans() {
-    return new Object[][]{{false}, {true}};
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{{false}, {true}});
   }
 
-  @Test(dataProvider = "booleans")
-  public void testResolveForeignJournalKey(final boolean useJournalKeyMap) throws Exception {
+  @Parameter
+  public boolean useJournalKeyMap;
+
+  @Test
+  public void testResolveForeignJournalKey() throws Exception {
     SiteRequestScheme dummyScheme = SiteRequestScheme.builder().build();
 
     Theme homeTheme = new StubTheme("homeTheme", "homeJournal") {
@@ -63,7 +72,6 @@ public class TestTheme {
 
     SiteSet siteSet = new SiteSet(ImmutableList.of(homeSite, targetSite));
     Site resolved = homeTheme.resolveForeignJournalKey(siteSet, "targetJournal");
-    assertEquals(resolved, targetSite);
+    assertEquals(targetSite, resolved);
   }
-
 }

--- a/src/test/java/org/ambraproject/wombat/config/theme/ThemeGraphTest.java
+++ b/src/test/java/org/ambraproject/wombat/config/theme/ThemeGraphTest.java
@@ -22,24 +22,24 @@
 
 package org.ambraproject.wombat.config.theme;
 
-import com.google.common.collect.ImmutableList;
-import org.ambraproject.wombat.config.TestSpringConfiguration;
-import org.ambraproject.wombat.config.site.Site;
-import org.ambraproject.wombat.config.site.SiteSet;
-import org.ambraproject.wombat.util.MockSiteUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.support.AnnotationConfigContextLoader;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
+import com.google.common.collect.ImmutableList;
+
+import org.ambraproject.wombat.config.TestSpringConfiguration;
+import org.ambraproject.wombat.config.site.Site;
+import org.ambraproject.wombat.config.site.SiteSet;
+import org.ambraproject.wombat.util.MockSiteUtil;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class)
-public class ThemeGraphTest extends AbstractTestNGSpringContextTests {
+public class ThemeGraphTest extends AbstractJUnit4SpringContextTests {
 
   @Autowired
   private SiteSet siteSet;
@@ -74,10 +74,10 @@ public class ThemeGraphTest extends AbstractTestNGSpringContextTests {
   private static void assertChainIs(ThemeGraph themeGraph, String themeKey, String... expectedParentKeys) {
     Theme themeUnderTest = themeGraph.getTheme(themeKey);
     ImmutableList<Theme> chain = themeUnderTest.getInheritanceChain();
-    assertEquals(chain.size(), 1 + expectedParentKeys.length);
-    assertEquals(chain.get(0), themeUnderTest);
+    assertEquals(1 + expectedParentKeys.length, chain.size());
+    assertEquals(themeUnderTest, chain.get(0));
     for (int i = 0; i < expectedParentKeys.length; i++) {
-      assertEquals(chain.get(i + 1), themeGraph.getTheme(expectedParentKeys[i]));
+      assertEquals(themeGraph.getTheme(expectedParentKeys[i]), chain.get(i + 1));
     }
   }
 
@@ -86,7 +86,7 @@ public class ThemeGraphTest extends AbstractTestNGSpringContextTests {
     TestClasspathTheme testClasspathTheme = new TestClasspathTheme();
     String classpathThemeKey = testClasspathTheme.getKey();
     ThemeGraph themeGraph = ThemeGraph.create(testClasspathTheme, ImmutableList.of(testClasspathTheme), THEME_GRAPH_CASE);
-    assertEquals(themeGraph.getThemes().size(), THEME_GRAPH_CASE.size() + 1);
+    assertEquals(THEME_GRAPH_CASE.size() + 1, themeGraph.getThemes().size());
 
     assertChainIs(themeGraph, classpathThemeKey);
     assertChainIs(themeGraph, "root1", classpathThemeKey);
@@ -103,7 +103,7 @@ public class ThemeGraphTest extends AbstractTestNGSpringContextTests {
     assertChainIs(themeGraph, "multichild2", "child1-1", "child1-2", "root1", "child2-1", "root2", classpathThemeKey);
   }
 
-  @Test(expectedExceptions = ThemeGraph.ThemeConfigurationException.class)
+  @Test(expected = ThemeGraph.ThemeConfigurationException.class)
   public void testParseCycle() throws ThemeGraph.ThemeConfigurationException {
     TestClasspathTheme testClasspathTheme = new TestClasspathTheme();
     ThemeGraph.create(testClasspathTheme, ImmutableList.of(testClasspathTheme), THEME_GRAPH_CYCLE_CASE);

--- a/src/test/java/org/ambraproject/wombat/controller/ArticleControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleControllerTest.java
@@ -55,7 +55,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 @ContextConfiguration
 public class ArticleControllerTest extends ControllerTest {

--- a/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
@@ -26,17 +26,18 @@ import org.ambraproject.wombat.identity.RequestedDoiVersion;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.ui.Model;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 @ContextConfiguration(classes = {ArticleMetadataTest.class})
-public class ArticleMetadataTest extends AbstractTestNGSpringContextTests {
+public class ArticleMetadataTest extends AbstractJUnit4SpringContextTests {
+
   @InjectMocks
   public ArticleMetadata.Factory articleMetadataFactory;
 
-  @BeforeMethod
+  @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }
@@ -95,7 +96,7 @@ public class ArticleMetadataTest extends AbstractTestNGSpringContextTests {
     articleMetadata.validateVisibility("whatever");
   }
 
-  @Test(expectedExceptions = InternalRedirectException.class)
+  @Test(expected = InternalRedirectException.class)
   public void testValidateVisibilityFail() {
     HashMap<String, String> journalMetadata = new HashMap<>();
     journalMetadata.put("journalKey", "someKey");

--- a/src/test/java/org/ambraproject/wombat/controller/CommentControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/CommentControllerTest.java
@@ -44,15 +44,15 @@ import org.ambraproject.wombat.identity.RequestedDoiVersion;
 import org.ambraproject.wombat.service.ArticleResolutionService;
 import org.ambraproject.wombat.service.ArticleService;
 import org.ambraproject.wombat.service.remote.ArticleApi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 @ContextConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -89,8 +89,8 @@ public class CommentControllerTest extends ControllerTest {
   RequestedDoiVersion expectedRequestedDoi;
   ArticlePointer expectedArticlePointer;
 
-  @BeforeMethod
-  private void setup() throws IOException {
+  @Before
+  public void setup() throws IOException {
     when(articleMetadata.validateVisibility(anyString())).thenReturn(articleMetadata);
     when(articleMetadata.populate(any(), any())).thenReturn(articleMetadata);
     when(articleMetadata.fillAmendments(any())).thenReturn(articleMetadata);
@@ -119,8 +119,8 @@ public class CommentControllerTest extends ControllerTest {
 
   private static final int EXPECTED_INGESTION_NUMBER = 2;
 
-  @AfterMethod
-  private void verifyCalls() throws IOException {
+  @After
+  public void verifyCalls() throws IOException {
     verify(articleResolutionService).toIngestion(expectedRequestedDoi);
     verify(articleService).getItemTable(expectedArticlePointer);
     verify(articleApi, times(2)).requestObject(any(), eq(Map.class));

--- a/src/test/java/org/ambraproject/wombat/controller/ControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ControllerTest.java
@@ -35,15 +35,17 @@ import com.google.common.base.Joiner;
 import org.ambraproject.wombat.config.SpringMvcConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
-import org.testng.annotations.BeforeMethod;
+import org.junit.Before;
 
 @WebAppConfiguration
 @ContextConfiguration(classes={ControllerTestConfiguration.class, SpringMvcConfiguration.class})
-public class ControllerTest extends AbstractTestNGSpringContextTests {
+public abstract class ControllerTest extends AbstractJUnit4SpringContextTests {
+
   protected static final Joiner NOSPACE_JOINER = Joiner.on("").skipNulls();
   protected static final String DESKTOP_PLOS_ONE = "DesktopPlosOne";
 
@@ -52,7 +54,7 @@ public class ControllerTest extends AbstractTestNGSpringContextTests {
 
   protected MockMvc mockMvc;
 
-  @BeforeMethod(alwaysRun = true)
+  @Before
   public void setupMockMvc() throws IOException {
     mockMvc = webAppContextSetup(wac).alwaysDo(print()).build();
   }

--- a/src/test/java/org/ambraproject/wombat/controller/PeerReviewControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/PeerReviewControllerTest.java
@@ -31,10 +31,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 @ContextConfiguration
 public class PeerReviewControllerTest extends ControllerTest {
@@ -47,8 +47,8 @@ public class PeerReviewControllerTest extends ControllerTest {
   PeerReviewController controller = new PeerReviewController();
   Map<String, Object> map;
 
-  @BeforeMethod
-  private void setup() throws IOException {
+  @Before
+  public void setup() throws IOException {
     this.map = new HashMap<String,Object>();
 
     when(articleMetadata.validateVisibility(anyString())).thenReturn(articleMetadata);
@@ -58,7 +58,7 @@ public class PeerReviewControllerTest extends ControllerTest {
     doReturn(articleMetadata).when(articleMetadataFactory).newInstance(any(), any(), any(), any(), any(), any());
   }
     
-  @Test(expectedExceptions = NotFoundException.class)
+  @Test(expected = NotFoundException.class)
   public void testPeerReviewNotFound(){
     controller.throwIfPeerReviewNotFound(map);
   }

--- a/src/test/java/org/ambraproject/wombat/controller/SearchControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/SearchControllerTest.java
@@ -30,8 +30,8 @@ import org.ambraproject.wombat.util.MockSiteUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -40,12 +40,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class)
-public class SearchControllerTest extends AbstractTestNGSpringContextTests {
-
+public class SearchControllerTest extends AbstractJUnit4SpringContextTests {
   @Autowired
   private SiteSet siteSet;
 
@@ -59,15 +58,15 @@ public class SearchControllerTest extends AbstractTestNGSpringContextTests {
     SearchController.CommonParams commonParams = new SearchController.CommonParams(siteSet, site);
     commonParams.parseParams(params, false);
 
-    assertEquals(commonParams.start, 90);  // Default results per page should be 15
-    assertEquals(commonParams.sortOrder, SolrSearchApiImpl.SolrSortOrder.RELEVANCE);
-    assertEquals(commonParams.dateRange, SolrSearchApiImpl.SolrEnumeratedDateRange.ALL_TIME);
+    assertEquals(90, commonParams.start);  // Default results per page should be 15
+    assertEquals(SolrSearchApiImpl.SolrSortOrder.RELEVANCE, commonParams.sortOrder);
+    assertEquals(SolrSearchApiImpl.SolrEnumeratedDateRange.ALL_TIME, commonParams.dateRange);
     assertTrue(commonParams.articleTypes.isEmpty());
     assertTrue(commonParams.journalKeys.isEmpty());
     assertTrue(commonParams.filterJournalNames.isEmpty());
-    assertEquals(commonParams.subjectList.size(), 2);
-    assertEquals(commonParams.subjectList.get(0), "subject1");
-    assertEquals(commonParams.subjectList.get(1), "subject2");
+    assertEquals(2, commonParams.subjectList.size());
+    assertEquals("subject1", commonParams.subjectList.get(0));
+    assertEquals("subject2", commonParams.subjectList.get(1));
     assertTrue(commonParams.isFiltered);
   }
 }

--- a/src/test/java/org/ambraproject/wombat/controller/StaticResourceControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/StaticResourceControllerTest.java
@@ -71,12 +71,15 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfig;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerViewResolver;
-import org.testng.annotations.Test;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import freemarker.cache.FileTemplateLoader;
 import freemarker.cache.MultiTemplateLoader;
@@ -85,6 +88,7 @@ import freemarker.template.TemplateDirectiveModel;
 
 @ContextConfiguration
 public class StaticResourceControllerTest extends ControllerTest {
+
   @Autowired
   AssetService assetService;
 

--- a/src/test/java/org/ambraproject/wombat/controller/TaxonomyControllerTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/TaxonomyControllerTest.java
@@ -40,12 +40,12 @@ import org.ambraproject.wombat.model.TaxonomyGraph;
 import org.ambraproject.wombat.model.TaxonomyGraph.CategoryView;
 import org.ambraproject.wombat.service.BrowseTaxonomyService;
 import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 @ContextConfiguration
 public class TaxonomyControllerTest extends ControllerTest {
@@ -66,8 +66,8 @@ public class TaxonomyControllerTest extends ControllerTest {
   @Autowired
   BrowseTaxonomyService browseTaxonomyService;
 
-  @BeforeMethod
-  private void setup() throws IOException {
+  @Before
+  public void setup() throws IOException {
     Map<String, Object> taxonomyBrowserConfig = new HashMap<String, Object>();
     taxonomyBrowserConfig.put("hasTaxonomyBrowser", true);
     when(theme.getConfigMap("taxonomyBrowser")).thenReturn(taxonomyBrowserConfig);

--- a/src/test/java/org/ambraproject/wombat/freemarker/HtmlElementTransformationTest.java
+++ b/src/test/java/org/ambraproject/wombat/freemarker/HtmlElementTransformationTest.java
@@ -26,7 +26,7 @@ import org.ambraproject.wombat.config.site.SiteSet;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.mockito.ArgumentCaptor;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import java.util.List;
 
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class HtmlElementTransformationTest {
 
@@ -68,12 +68,12 @@ public class HtmlElementTransformationTest {
     verify(sitePageContext).buildLink(any(SiteSet.class), journalKeyArg.capture(), pathArg.capture());
 
     List<String> pathArgs = pathArg.getAllValues();
-    assertEquals(pathArgs.get(0), "s/lorum_ipsum");
-    assertEquals(pathArgs.get(1), "s/file?id=file_4321");
-    assertEquals(pathArgs.get(2), "indirect/content_1234");
-    assertEquals(pathArgs.get(3), "article?id=10.1371/journal.pone.0008083");
-    assertEquals(pathArgs.get(4), "s/test-page");
-    assertEquals(journalKeyArg.getValue(), "PLoSCompBiol");
+    assertEquals("s/lorum_ipsum", pathArgs.get(0));
+    assertEquals("s/file?id=file_4321", pathArgs.get(1));
+    assertEquals("indirect/content_1234", pathArgs.get(2));
+    assertEquals("article?id=10.1371/journal.pone.0008083", pathArgs.get(3));
+    assertEquals("s/test-page", pathArgs.get(4));
+    assertEquals("PLoSCompBiol", journalKeyArg.getValue());
 
     assertEquals(document.toString(),
             "<html>\n" +

--- a/src/test/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirectiveTest.java
+++ b/src/test/java/org/ambraproject/wombat/freemarker/ReplaceParametersDirectiveTest.java
@@ -29,14 +29,14 @@ import com.google.common.collect.Multimap;
 import freemarker.template.SimpleHash;
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateModel;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ReplaceParametersDirectiveTest {
 
@@ -56,7 +56,7 @@ public class ReplaceParametersDirectiveTest {
         .putAll("multiValuedParam", "value1", "value2")
         .put("emptyParam", "")
         .put("paramToReplace", "newValue");
-    assertEquals(actual, expected.build());
+    assertEquals(expected.build(), actual);
   }
 
   @Test
@@ -75,6 +75,6 @@ public class ReplaceParametersDirectiveTest {
         .putAll("multiValuedParam", "value1", "value2")
         .put("emptyParam", "")
         .put("paramToReplace", "newValue");
-    assertEquals(actual, expected.build());
+    assertEquals(expected.build(), actual);
   }
 }

--- a/src/test/java/org/ambraproject/wombat/model/SearchFilterFactoryTest.java
+++ b/src/test/java/org/ambraproject/wombat/model/SearchFilterFactoryTest.java
@@ -8,16 +8,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 
 @ContextConfiguration(classes = {ArticleResolutionServiceTest.class})
-public class SearchFilterFactoryTest extends AbstractTestNGSpringContextTests {
+public class SearchFilterFactoryTest extends AbstractJUnit4SpringContextTests {
 
   @Mock
   private SearchFilterTypeMap filterTypeMap;
@@ -25,7 +25,7 @@ public class SearchFilterFactoryTest extends AbstractTestNGSpringContextTests {
   @InjectMocks
   private SearchFilterFactory searchFilterFactory;
 
-  @BeforeMethod
+  @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }
@@ -50,10 +50,10 @@ public class SearchFilterFactoryTest extends AbstractTestNGSpringContextTests {
     String filterTypeMapKey = "journal";
     SearchFilter searchFilter = searchFilterFactory.createSearchFilter(results, filterTypeMapKey, params);
 
-    assertEquals("journal", searchFilter.getFilterTypeMapKey());
-    assertEquals("PLOS ONE", searchFilter.getSearchFilterResult().get(0).getDisplayName());
-    assertEquals(new Float(19.0f), new Float(searchFilter.getSearchFilterResult().get(0).getNumberOfHits()));
-    assertEquals("PLOS Computational Biology", searchFilter.getSearchFilterResult().get(1).getDisplayName());
-    assertEquals(new Float(412.0f), new Float(searchFilter.getSearchFilterResult().get(1).getNumberOfHits()));
+    assertEquals(searchFilter.getFilterTypeMapKey(), "journal");
+    assertEquals(searchFilter.getSearchFilterResult().get(0).getDisplayName(), "PLOS ONE");
+    assertEquals(new Float(searchFilter.getSearchFilterResult().get(0).getNumberOfHits()), new Float(19.0f));
+    assertEquals(searchFilter.getSearchFilterResult().get(1).getDisplayName(), "PLOS Computational Biology");
+    assertEquals(new Float(searchFilter.getSearchFilterResult().get(1).getNumberOfHits()), new Float(412.0f));
   }
 }

--- a/src/test/java/org/ambraproject/wombat/service/ArticleResolutionServiceTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/ArticleResolutionServiceTest.java
@@ -9,9 +9,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -20,10 +20,10 @@ import java.util.OptionalInt;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @ContextConfiguration(classes = {ArticleResolutionServiceTest.class})
-public class ArticleResolutionServiceTest extends AbstractTestNGSpringContextTests {
+public class ArticleResolutionServiceTest extends AbstractJUnit4SpringContextTests {
 
   @Mock
   private ArticleApi articleApi;
@@ -31,7 +31,7 @@ public class ArticleResolutionServiceTest extends AbstractTestNGSpringContextTes
   @InjectMocks
   private ArticleResolutionService articleResolutionService;
 
-  @BeforeMethod
+  @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }
@@ -43,13 +43,13 @@ public class ArticleResolutionServiceTest extends AbstractTestNGSpringContextTes
 
     RequestedDoiVersion assetId = RequestedDoiVersion.of("info:doi/10.1371/journal.pcbi.1002012.g002");
     AssetPointer assetPointer = articleResolutionService.toParentIngestion(assetId);
-    assertEquals(assetPointer.getAssetDoi(), "10.1371/journal.pcbi.1002012.g002");
-    assertEquals(assetPointer.getParentArticle().getDoi(), "10.1371/journal.pcbi.1002012");
-    assertEquals(assetPointer.getParentArticle().getIngestionNumber(), 1);
-    assertEquals(assetPointer.getParentArticle().getRevisionNumber().getAsInt(), 1);
+    assertEquals("10.1371/journal.pcbi.1002012.g002", assetPointer.getAssetDoi());
+    assertEquals("10.1371/journal.pcbi.1002012", assetPointer.getParentArticle().getDoi());
+    assertEquals(1, assetPointer.getParentArticle().getIngestionNumber());
+    assertEquals(1, assetPointer.getParentArticle().getRevisionNumber().getAsInt());
   }
 
-  @Test(expectedExceptions = NotFoundException.class)
+  @Test(expected = NotFoundException.class)
   public void testToParentIngestionNotAnAsset() throws IOException {
     Map<String, Object> doiOverview = makeSampleDoiOverview();
     doiOverview.put("type", "not_an_asset_type");
@@ -67,10 +67,10 @@ public class ArticleResolutionServiceTest extends AbstractTestNGSpringContextTes
     RequestedDoiVersion assetId = RequestedDoiVersion.ofIngestion(
         "info:doi/10.1371/journal.pcbi.1002012.g002", 1);
     AssetPointer assetPointer = articleResolutionService.toParentIngestion(assetId);
-    assertEquals(assetPointer.getAssetDoi(), "10.1371/journal.pcbi.1002012.g002");
-    assertEquals(assetPointer.getParentArticle().getDoi(), "10.1371/journal.pcbi.1002012");
-    assertEquals(assetPointer.getParentArticle().getIngestionNumber(), 1);
-    assertEquals(assetPointer.getParentArticle().getRevisionNumber(), OptionalInt.empty());
+    assertEquals("10.1371/journal.pcbi.1002012.g002", assetPointer.getAssetDoi());
+    assertEquals("10.1371/journal.pcbi.1002012", assetPointer.getParentArticle().getDoi());
+    assertEquals(1, assetPointer.getParentArticle().getIngestionNumber());
+    assertEquals(OptionalInt.empty(), assetPointer.getParentArticle().getRevisionNumber());
   }
 
   @Test
@@ -81,10 +81,10 @@ public class ArticleResolutionServiceTest extends AbstractTestNGSpringContextTes
     RequestedDoiVersion assetId = RequestedDoiVersion.ofRevision(
         "info:doi/10.1371/journal.pcbi.1002012.g002", 1);
     AssetPointer assetPointer = articleResolutionService.toParentIngestion(assetId);
-    assertEquals(assetPointer.getAssetDoi(), "10.1371/journal.pcbi.1002012.g002");
-    assertEquals(assetPointer.getParentArticle().getDoi(), "10.1371/journal.pcbi.1002012");
-    assertEquals(assetPointer.getParentArticle().getIngestionNumber(), 1);
-    assertEquals(assetPointer.getParentArticle().getRevisionNumber().getAsInt(), 1);
+    assertEquals("10.1371/journal.pcbi.1002012.g002", assetPointer.getAssetDoi());
+    assertEquals("10.1371/journal.pcbi.1002012", assetPointer.getParentArticle().getDoi());
+    assertEquals(1, assetPointer.getParentArticle().getIngestionNumber());
+    assertEquals(1, assetPointer.getParentArticle().getRevisionNumber().getAsInt());
 
   }
 

--- a/src/test/java/org/ambraproject/wombat/service/AssetServiceTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/AssetServiceTest.java
@@ -22,7 +22,7 @@
 
 package org.ambraproject.wombat.service;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileReader;
@@ -34,18 +34,19 @@ import com.google.common.base.Joiner;
 import org.ambraproject.wombat.config.RuntimeConfiguration;
 import org.ambraproject.wombat.config.TestSpringConfiguration;
 import org.ambraproject.wombat.config.site.SiteSet;
+import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 @ContextConfiguration
-public class AssetServiceTest extends AbstractTestNGSpringContextTests {
+public class AssetServiceTest extends AbstractJUnit4SpringContextTests {
   @Import(TestSpringConfiguration.class)
   @Configuration
   static class ContextConfiguration {
@@ -80,7 +81,7 @@ public class AssetServiceTest extends AbstractTestNGSpringContextTests {
            FileReader reader2 = new FileReader(new File(DATA_PATH + "test2.js"))) {
         jsContext.evaluateReader(jsScope, reader1, "test1.js", 1, null);
         expected = jsContext.evaluateReader(jsScope, reader2, "test2.js", 1, null);
-        assertEquals(expected, "magicValue");
+        assertEquals("magicValue", expected);
       }
     }
 
@@ -99,14 +100,14 @@ public class AssetServiceTest extends AbstractTestNGSpringContextTests {
     File file = new File(runtimeConfiguration.getCompiledAssetDir() + File.separator + basename);
     try (FileReader fr = new FileReader(file)) {
       Object actual = jsContext.evaluateReader(jsScope, fr, basename, 1, null);
-      assertEquals(actual, expected);
+      assertEquals(expected, actual);
     }
   }
 
   /**
    * Tests that invalid javascript cannot be compiled.
    */
-  @Test(expectedExceptions = {AssetCompilationException.class})
+  @Test(expected = AssetCompilationException.class)
   public void testJsError() throws Exception {
     List<String> jsFiles = new ArrayList<>();
     jsFiles.add("resource/js/error.js");

--- a/src/test/java/org/ambraproject/wombat/service/CommentFormattingTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/CommentFormattingTest.java
@@ -25,15 +25,20 @@ package org.ambraproject.wombat.service;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.ambraproject.wombat.service.CommentFormatting.FormattedComment;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class CommentFormattingTest {
 
   private static class TestCase {
@@ -90,20 +95,23 @@ public class CommentFormattingTest {
     }
   }
 
-  @DataProvider
-  public Object[][] getTestCases() {
+  @Parameters
+  public static List<Object[]> getTestCases() {
     return TEST_CASES.stream()
-        .map(testCase -> new Object[]{testCase})
-        .collect(Collectors.toList()).toArray(new Object[0][]);
+      .map(testCase -> new Object[]{testCase})
+      .collect(Collectors.toList());
   }
 
-  @Test(dataProvider = "getTestCases")
-  public void testCommentFormatting(TestCase testCase) {
+  @Parameter(0)
+  public TestCase testCase;
+
+  @Test
+  public void testCommentFormatting() {
     Map<String, Object> view = testCase.createView();
     CommentFormatting.addFormattingFields(view);
     FormattedComment formatted = (FormattedComment) view.get("formatting");
-    assertEquals(formatted.getBodyWithHighlightedText(), testCase.expectedBodyWithHighlightedText);
-    assertEquals(formatted.getCompetingInterestStatement(), testCase.expectedCompetingInterestStatement);
+    assertEquals(testCase.expectedBodyWithHighlightedText, formatted.getBodyWithHighlightedText());
+    assertEquals(testCase.expectedCompetingInterestStatement, formatted.getCompetingInterestStatement());
   }
 
   private static final ImmutableList<TestCase> TEST_CASES = ImmutableList.copyOf(new TestCase[]{

--- a/src/test/java/org/ambraproject/wombat/service/PeerReviewServiceTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/PeerReviewServiceTest.java
@@ -11,9 +11,9 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import org.ambraproject.wombat.service.remote.ContentKey;
 
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.spy;
 
 
 @ContextConfiguration(classes = {PeerReviewServiceTest.class})
-public class PeerReviewServiceTest extends AbstractTestNGSpringContextTests {
+public class PeerReviewServiceTest extends AbstractJUnit4SpringContextTests {
 
   private PeerReviewServiceImpl service = new PeerReviewServiceImpl();
 

--- a/src/test/java/org/ambraproject/wombat/service/SearchFilterServiceTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/SearchFilterServiceTest.java
@@ -9,9 +9,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ContextConfiguration(classes = {SearchFilterServiceTest.class})
-public class SearchFilterServiceTest extends AbstractTestNGSpringContextTests {
+public class SearchFilterServiceTest extends AbstractJUnit4SpringContextTests {
 
   @Mock
   private SolrSearchApi solrSearchApi;
@@ -33,7 +33,7 @@ public class SearchFilterServiceTest extends AbstractTestNGSpringContextTests {
   @InjectMocks
   private SearchFilterService searchFilterService;
 
-  @BeforeMethod
+  @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }

--- a/src/test/java/org/ambraproject/wombat/service/remote/SolrSearchApiTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/remote/SolrSearchApiTest.java
@@ -35,8 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,13 +50,13 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @ContextConfiguration(classes = TestSpringConfiguration.class)
-public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
+public class SolrSearchApiTest extends AbstractJUnit4SpringContextTests {
 
   @Autowired
   private SiteSet siteSet;
@@ -78,27 +78,27 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
     // query string not null
     List<NameValuePair> actual = buildCommonParams("foo", true, 0, 10, SolrSearchApiImpl.SolrSortOrder.MOST_CITED, true);
     SetMultimap<String, String> actualMap = convertToMap(actual);
-    assertCommonParams(actualMap, 2);
-    assertSingle(actualMap.get("rows"), "10");
+    assertCommonParams(2, actualMap);
+    assertSingle("10", actualMap.get("rows"));
 
     // if start == 0 no param should be present.
-    assertEquals(actualMap.get("start").size(), 0);
-    assertSingle(actualMap.get("sort"), "alm_scopusCiteCount desc,id desc");
-    assertSingle(actualMap.get("defType"), "dismax");
-    assertSingle(actualMap.get("q"), "foo");
+    assertEquals(0, actualMap.get("start").size());
+    assertSingle("alm_scopusCiteCount desc,id desc", actualMap.get("sort"));
+    assertSingle("dismax", actualMap.get("defType"));
+    assertSingle("foo", actualMap.get("q"));
 
     // empty query string
     actual = buildCommonParams("", false, 0, 10, SolrSearchApiImpl.SolrSortOrder.MOST_CITED, true);
     actualMap = convertToMap(actual);
-    assertCommonParams(actualMap, 2);
-    assertEquals(actualMap.get("defType").size(), 0);
-    assertSingle(actualMap.get("q"), "*:*");
+    assertCommonParams(2, actualMap);
+    assertEquals(0, actualMap.get("defType").size());
+    assertSingle("*:*", actualMap.get("q"));
 
     // not home page
     actual = buildCommonParams("", false, 0, 10, SolrSearchApiImpl.SolrSortOrder.RELEVANCE, false);
     actualMap = convertToMap(actual);
-    assertCommonParams(actualMap, 2);
-    assertSingle(actualMap.get("sort"), "score desc,publication_date desc,id desc");
+    assertSingle("score desc,publication_date desc,id desc", actualMap.get("sort"));
+    assertCommonParams(2, actualMap);
 
   }
 
@@ -115,18 +115,18 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
     // query string not null
     List<NameValuePair> actual = buildFacetParams("journal", "foo", true);
     SetMultimap<String, String> actualMap = convertToMap(actual);
-    assertFacetParams(actualMap, 2);
-    assertSingle(actualMap.get("facet.field"), "journal");
-    assertSingle(actualMap.get("defType"), "dismax");
-    assertSingle(actualMap.get("q"), "foo");
+    assertFacetParams(2, actualMap);
+    assertSingle("journal", actualMap.get("facet.field"));
+    assertSingle("dismax", actualMap.get("defType"));
+    assertSingle("foo", actualMap.get("q"));
 
     // empty query string
     actual = buildFacetParams("journal", "", false);
     actualMap = convertToMap(actual);
-    assertFacetParams(actualMap, 2);
-    assertSingle(actualMap.get("facet.field"), "journal");
+    assertFacetParams(2, actualMap);
+    assertSingle("journal", actualMap.get("facet.field"));
     assertEquals(actualMap.get("defType").size(), 0);
-    assertSingle(actualMap.get("q"), "*:*");
+    assertSingle("*:*", actualMap.get("q"));
   }
 
   private static void setQueryFilters(List<NameValuePair> params, List<String> journalKeys,
@@ -157,7 +157,7 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
     setQueryFilters(actual, Collections.singletonList("foo"), articleTypes, subjects,
         SolrSearchApiImpl.SolrEnumeratedDateRange.LAST_3_MONTHS);
     actualMap = convertToMap(actual);
-    assertEquals(actualMap.get("fq").size(), 2);
+    assertEquals(2, actualMap.get("fq").size());
     for (String s : actualMap.get("fq")) {
       if (!s.contains("publication_date:") && !s.contains("journal_key:")) {
         fail(s);
@@ -232,9 +232,9 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
   @Test
   public void testAddArticleLinks() throws IOException {
     SolrSearchApi solrSearchApiForTest = new SearchApiForAddArticleLinksTest();
-    Map<String, List<Map>> searchResults = new HashMap<>();
-    List<Map> docs = new ArrayList<>(1);
-    Map doc = new HashMap();
+    Map<String, List<Map<String,String>>> searchResults = new HashMap<>();
+    List<Map<String,String>> docs = new ArrayList<>(1);
+    Map<String,String> doc = new HashMap<>();
     List<String> crossPubbedJournals = new ArrayList<>(1);
     crossPubbedJournals.add("journal1Key");
     doc.put("id", "12345");
@@ -247,15 +247,15 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
 
     Map<?, ?> actual = solrSearchApiForTest.addArticleLinks(searchResults, request, site, siteSet);
     List<Map> actualDocs = (List) actual.get("docs");
-    assertEquals(actualDocs.size(), 1);
+    assertEquals(1, actualDocs.size());
     Map actualDoc = (Map) actualDocs.get(0);
-    assertEquals(actualDoc.get("id"), "12345");
+    assertEquals("12345", actualDoc.get("id"));
     assertTrue(actualDoc.get("link").toString().endsWith("someContextPath/site1/article?id=12345"));
   }
 
   @Test
   public void testBuildSubjectClause() {
-    assertEquals(ArticleSearchQuery.buildSubjectClause(Arrays.asList("foo")), "subject:\"foo\"");
+    assertEquals("subject:\"foo\"", ArticleSearchQuery.buildSubjectClause(Arrays.asList("foo")));
     assertEquals(ArticleSearchQuery.buildSubjectClause(Arrays.asList("foo", "2nd subject")),
         "subject:\"foo\" AND subject:\"2nd subject\"");
   }
@@ -281,41 +281,40 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
   /**
    * Tests for parameters expected to be the same across all tests.
    */
-  private void assertCommonParams(SetMultimap<String, String> actual, int expectedNumFqParams) {
-    assertSingle(actual.get("wt"), "json");
+  private void assertCommonParams(int expectedNumFqParams, SetMultimap<String, String> actual) {
+    assertSingle("json", actual.get("wt"));
     Set<String> fq = actual.get("fq");
 
     // We check two of the fq params here; the caller should check the others.
     Joiner joiner = Joiner.on(",");
-    assertEquals(fq.size(), expectedNumFqParams, joiner.join(fq));
+    assertEquals(expectedNumFqParams, fq.size());
     assertTrue(fq.contains("doc_type:full"));
     assertTrue(fq.contains("!article_type_facet:\"Issue Image\""));
-    assertSingle(actual.get("hl"), "false");
-    assertSingle(actual.get("facet"), "false");
+    assertSingle("false", actual.get("hl"));
+    assertSingle("false", actual.get("facet"));
   }
 
   /**
    * Tests for parameters expected to be the same across all tests.
    */
-  private void assertFacetParams(SetMultimap<String, String> actual, int expectedNumFqParams) {
-    assertSingle(actual.get("wt"), "json");
-    assertSingle(actual.get("json.nl"), "map");
+  private void assertFacetParams(int expectedNumFqParams, SetMultimap<String, String> actual) {
+    assertSingle("json", actual.get("wt"));
+    assertSingle("map", actual.get("json.nl"));
     Set<String> fq = actual.get("fq");
 
     // We check two of the fq params here; the caller should check the others.
-    Joiner joiner = Joiner.on(",");
-    assertEquals(fq.size(), expectedNumFqParams, joiner.join(fq));
+    assertEquals(expectedNumFqParams, fq.size());
     assertTrue(fq.contains("doc_type:full"));
     assertTrue(fq.contains("!article_type_facet:\"Issue Image\""));
-    assertSingle(actual.get("hl"), "false");
-    assertSingle(actual.get("facet"), "true");
+    assertSingle("false", actual.get("hl"));
+    assertSingle("true", actual.get("facet"));
   }
 
   /**
    * Asserts that the given set (all values of a single parameter) has exactly one entry with the expected value.
    */
-  private void assertSingle(Set<String> multimapSet, String expected) {
-    assertEquals(multimapSet.size(), 1);
+  private void assertSingle(String expected, Set<String> multimapSet) {
+    assertEquals(1, multimapSet.size());
     assertTrue(multimapSet.contains(expected));
   }
 
@@ -355,7 +354,7 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
     // For multiple journals, the expected format of the param is
     // "journal_key:PLoSBiology OR journal_key:PLoSONE"
     String[] parts = journals.split(" OR ");
-    assertEquals(parts.length, expectedJournals.length);
+    assertEquals(expectedJournals.length, parts.length);
     Set<String> actualJournals = new HashSet<>();
     for (String part : parts) {
       actualJournals.add(part.substring("journal_key:".length()));
@@ -391,7 +390,7 @@ public class SolrSearchApiTest extends AbstractTestNGSpringContextTests {
     // For multiple subjects, the expected format of the param is
     // "subject:Teeth AND subject:Head"
     String[] parts = subjects.split(" AND ");
-    assertEquals(parts.length, expectedSubjects.length);
+    assertEquals(expectedSubjects.length, parts.length);
     Set<String> actualSubjects = new HashSet<>();
     for (String part : parts) {
       actualSubjects.add(part.substring("subject:".length()));

--- a/src/test/java/org/ambraproject/wombat/util/CacheKeyTest.java
+++ b/src/test/java/org/ambraproject/wombat/util/CacheKeyTest.java
@@ -26,14 +26,13 @@ package org.ambraproject.wombat.util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class CacheKeyTest {
-
   @Test
   public void testGetCacheKey(){
     String exampleUrl1 = "articles?journal=PLoSPathogens&min=3&since=Thu%2C+30+Oct+2014+00%3A55%3A34+GMT&type=" +
@@ -51,9 +50,9 @@ public class CacheKeyTest {
     String hash1 = CacheKey.createKeyHash(ImmutableList.of(exampleUrl1));
     String hash2 = CacheKey.createKeyHash(ImmutableList.of(exampleUrl2));
 
-    Assert.assertFalse(hash1.contentEquals(exampleUrl1), "Hash key generation failure");
-    Assert.assertTrue(hash1.contentEquals(CacheKey.createKeyHash(ImmutableList.of(exampleUrl1))), "Non-deterministic hash key");
-    Assert.assertFalse(hash1.contentEquals(hash2), "Hash keys are not unique");
+    Assert.assertFalse("Hash key generation failure", hash1.contentEquals(exampleUrl1));
+    Assert.assertTrue("Non-deterministic hash key", hash1.contentEquals(CacheKey.createKeyHash(ImmutableList.of(exampleUrl1))));
+    Assert.assertFalse("Hash keys are not unique", hash1.contentEquals(hash2));
     byte[] hash1Bytes;
     try {
       hash1Bytes = CacheKey.HASH_BASE.decode(hash1);
@@ -61,7 +60,7 @@ public class CacheKeyTest {
       Assert.fail("Hash keys are not in base-encoded format");
       throw e; // satisfy the compiler
     }
-    Assert.assertTrue(hash1Bytes.length == keyLen, "Incorrect hash length");
+    Assert.assertTrue("Incorrect hash length", hash1Bytes.length == keyLen);
 
     Map<Object, String> expectedHashes = new HashMap<>();
     expectedHashes.put(Hashing.md5(), "25FF3F5D3A44A1C19DD9F54773C4D32D");
@@ -71,7 +70,7 @@ public class CacheKeyTest {
             "F763BAB884DA75F91A0768DAD30D0E6F5E5AA2361A0B3F5AEF757B7");
     if (expectedHashes.keySet().contains(CacheKey.HASH_ALGORITHM)) {
       byte[] expectedHash = BaseEncoding.base16().decode(expectedHashes.get(CacheKey.HASH_ALGORITHM));
-      Assert.assertEquals(hash1Bytes, expectedHash, "Incorrect hash");
+      Assert.assertArrayEquals("Incorrect hash", hash1Bytes, expectedHash);
     }
   }
 }

--- a/src/test/java/org/ambraproject/wombat/util/GitInfoTest.java
+++ b/src/test/java/org/ambraproject/wombat/util/GitInfoTest.java
@@ -22,8 +22,8 @@
 
 package org.ambraproject.wombat.util;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class GitInfoTest {
 
@@ -31,20 +31,20 @@ public class GitInfoTest {
   public void testCheckGitValues() {
     GitInfo gitInfo = new GitInfo();
 
-    Assert.assertEquals(gitInfo.getBranch(), "", "git branch value is incorrect");
+    Assert.assertEquals("git branch value is incorrect", "", gitInfo.getBranch());
 
-    Assert.assertEquals(gitInfo.getDescribe(), "", "git describe value is incorrect");
+    Assert.assertEquals("git describe value is incorrect", "", gitInfo.getDescribe());
 
-    Assert.assertEquals(gitInfo.getBuildUserName(), "", "git build user name value is incorrect");
-    Assert.assertEquals(gitInfo.getBuildUserEmail(), "", "git build user email value is incorrect");
-    Assert.assertEquals(gitInfo.getBuildTime(), "05.06.2014 @ 14:42:36 PDT", "git build time value is incorrect");
+    Assert.assertEquals("git build user name value is incorrect", "", gitInfo.getBuildUserName());
+    Assert.assertEquals("git build user email value is incorrect", "", gitInfo.getBuildUserEmail());
+    Assert.assertEquals("git build time value is incorrect", "05.06.2014 @ 14:42:36 PDT", gitInfo.getBuildTime());
 
-    Assert.assertEquals(gitInfo.getCommitId(), "bb2bdabf1d38c720a7871befa2e98e03ade1a2c3", "git commit id value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitIdAbbrev(), "bb2bdab", "git commit id abbrev value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitUserName(), "", "git commit user name value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitUserEmail(), "", "git cinnut yser enauk value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitMessageFull(), "commit message FULL!!", "git commit message full value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitMessageShort(), "commit message short", "git commit message short value is incorrect");
-    Assert.assertEquals(gitInfo.getCommitTime(), "05.06.2014 @ 14:37:41 PDT", "git commit time value is incorrect");
+    Assert.assertEquals("git commit id value is incorrect", "bb2bdabf1d38c720a7871befa2e98e03ade1a2c3", gitInfo.getCommitId());
+    Assert.assertEquals("git commit id abbrev value is incorrect", "bb2bdab", gitInfo.getCommitIdAbbrev());
+    Assert.assertEquals("git commit user name value is incorrect", "", gitInfo.getCommitUserName());
+    Assert.assertEquals("git commit user email value is incorrect", "", gitInfo.getCommitUserEmail());
+    Assert.assertEquals("git commit message full value is incorrect", "commit message FULL!!", gitInfo.getCommitMessageFull());
+    Assert.assertEquals("git commit message short value is incorrect", "commit message short", gitInfo.getCommitMessageShort());
+    Assert.assertEquals("git commit time value is incorrect", "05.06.2014 @ 14:37:41 PDT", gitInfo.getCommitTime());
   }
 }

--- a/src/test/java/org/ambraproject/wombat/util/HttpMessageUtilTest.java
+++ b/src/test/java/org/ambraproject/wombat/util/HttpMessageUtilTest.java
@@ -22,21 +22,22 @@
 
 package org.ambraproject.wombat.util;
 
-import com.google.common.collect.ImmutableList;
-import org.apache.http.Header;
-import org.apache.http.HttpResponse;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.message.BasicHttpResponse;
-import org.springframework.http.HttpStatus;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.testng.annotations.Test;
+import static org.ambraproject.wombat.util.HttpMessageUtil.copyResponseWithHeaders;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static org.ambraproject.wombat.util.HttpMessageUtil.HeaderFilter;
-import static org.ambraproject.wombat.util.HttpMessageUtil.copyResponseWithHeaders;
-import static org.testng.Assert.assertEquals;
+import com.google.common.collect.ImmutableList;
+
+import org.ambraproject.wombat.util.HttpMessageUtil.HeaderFilter;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 public class HttpMessageUtilTest {
 
@@ -63,12 +64,12 @@ public class HttpMessageUtilTest {
 
     copyResponseWithHeaders(input, output, headerFilter);
 
-    assertEquals(output.getContentAsByteArray(), testContent);
+    assertArrayEquals(testContent, output.getContentAsByteArray());
 
-    assertEquals(output.getHeaderNames().size(), 2);
-    assertEquals(output.getHeaders("includeMe"), ImmutableList.of("foo"));
-    assertEquals(output.getHeaders("alterMe"), ImmutableList.of("altered"));
-    assertEquals(output.getHeaders("excludeMe"), ImmutableList.of());
+    assertEquals(2, output.getHeaderNames().size());
+    assertEquals(ImmutableList.of("foo"), output.getHeaders("includeMe"));
+    assertEquals(ImmutableList.of("altered"), output.getHeaders("alterMe"));
+    assertEquals(ImmutableList.of(), output.getHeaders("excludeMe"));
   }
 
 }

--- a/src/test/java/org/ambraproject/wombat/util/TextUtilTest.java
+++ b/src/test/java/org/ambraproject/wombat/util/TextUtilTest.java
@@ -22,8 +22,8 @@
 
 package org.ambraproject.wombat.util;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TextUtilTest {
 
@@ -31,24 +31,24 @@ public class TextUtilTest {
   public void testRemoveFootnoteMarker() {
     String expectedResult = " Current address: Joint Genome Institute, Walnut Creek, California, United States of America";
     String actualResult = TextUtil.removeFootnoteMarker("¤b Current address: Joint Genome Institute, Walnut Creek, California, United States of America");
-    Assert.assertEquals(actualResult, expectedResult, "Footnote marker was not replaced");
+    Assert.assertEquals("Footnote marker was not replaced", expectedResult, actualResult);
 
     expectedResult = "Current  Current address: Joint Genome Institute, Walnut Creek, California, United States of America";
     actualResult = TextUtil.removeFootnoteMarker("Current ¤b Current address: Joint Genome Institute, Walnut Creek, California, United States of America");
-    Assert.assertEquals(actualResult, expectedResult, "Footnote marker was not replaced");
+    Assert.assertEquals("Footnote marker was not replaced", expectedResult, actualResult);
 
   }
 
   @Test
   public void testSanitizeWhitespace() {
-    Assert.assertEquals(TextUtil.sanitizeWhitespace(""), "");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("foo"), "foo");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("foo bar"), "foo bar");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace(" foo bar"), "foo bar");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("foo bar "), "foo bar");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("foo  bar"), "foo bar");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("   foo  bar   "), "foo bar");
-    Assert.assertEquals(TextUtil.sanitizeWhitespace("\n\r foo\tbar \n \n "), "foo bar");
+    Assert.assertEquals("", TextUtil.sanitizeWhitespace(""));
+    Assert.assertEquals("foo", TextUtil.sanitizeWhitespace("foo"));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace("foo bar"));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace(" foo bar"));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace("foo bar "));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace("foo  bar"));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace("   foo  bar   "));
+    Assert.assertEquals("foo bar", TextUtil.sanitizeWhitespace("\n\r foo\tbar \n \n "));
     Assert.assertEquals(TextUtil.sanitizeWhitespace(
             " A Phase Two Randomised Controlled Double Blind Trial of High Dose\n" +
                 "                    Intravenous Methylprednisolone and Oral Prednisolone versus Intravenous Normal\n" +


### PR DESCRIPTION
junit is a more standard library and has better integration with IDEs.

## What this PR does:

junit is a more standard java testing library. It has better support in eclipse and netbeans. It is almost indistinguishable in the way that we use it from testng. It is used in content-repo.

Also, junit 5 is a nice looking, very modern java library, if we ever want to upgrade.


# Code Author Tasks:

> This list should be finished before code review:

- [x] All PRs are created and linked for work I have done against other projects as part of this ticket.
- [x] There are unit tests sufficient for both positive and negative test cases, test coverage has not decreased as part of this work. 
- [x] Any necessary documentation in confluence or READMEs is updated.

If I used outside libraries:
- [x] Confirmed unique - we aren't using something similar elsewhere
- [x] License comports with our licensing (MIT preferable)

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
