### PR TITLE
AMBR-906 Fix compression option

### DIFF
--- a/src/deb/tomcat8/conf/server.template.xml
+++ b/src/deb/tomcat8/conf/server.template.xml
@@ -21,7 +21,7 @@
                enableLookups="false"
                maxParameterCount="5000"
                scheme="http" URIEncoding="UTF-8"
-               compression="true"
+               compression="on"
                minSpareThreads="50" maxThreads="1000"/>
     <Engine name="Catalina" defaultHost="localhost">
       <Realm className="org.apache.catalina.realm.LockOutRealm">


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-906

## What this PR does:

I messed this one up. It turns on the compression was happening in apache, not in tomcat. This is the correct option to use.

See https://tomcat.apache.org/tomcat-8.5-doc/config/http.html

Now we will have compression in both tomcat and apache. This is fine. See https://jira.plos.org/jira/browse/AMBR-862?focusedCommentId=245360&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-245360 for some tests I did comparing the various gzip filters being enabled.

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
