### PR TITLE
Ambr 864 jats

### DIFF
--- a/src/main/resources/peer-review-transform.xsl
+++ b/src/main/resources/peer-review-transform.xsl
@@ -218,4 +218,118 @@
        date is referenced directly in revision #0 block --> 
   <xsl:template match="article-received-date" />
 
+  <xsl:template match="italic">
+    <em>
+      <xsl:apply-templates/>
+    </em>
+  </xsl:template>
+
+  <xsl:template match="monospace">
+    <span class="monospace">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="strike">
+    <span class="strike">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="underline">
+    <span class="underline">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="disp-quote">
+    <xsl:call-template name="newline1"/>
+    <blockquote>
+      <xsl:call-template name="assign-id"/>
+      <xsl:apply-templates/>
+    </blockquote>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <xsl:template name="assign-id">
+    <xsl:if test="@id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="newline1">
+    <xsl:text>&#xA;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="sub">
+    <sub>
+      <xsl:apply-templates/>
+    </sub>
+  </xsl:template>
+
+  <xsl:template match="sup">
+    <sup>
+      <xsl:apply-templates/>
+    </sup>
+  </xsl:template>
+
+  <xsl:template match="list-item">
+    <xsl:call-template name="newline1"/>
+    <li>
+      <xsl:if test="../@prefix-word">
+        <xsl:value-of select="../@prefix-word"/>
+        <xsl:text> </xsl:text>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </li>
+    <xsl:call-template name="newline1"/>
+  </xsl:template>
+
+  <xsl:template match="list-item/label">
+    <span class="list-label">
+      <xsl:apply-templates/>
+      <xsl:text>. </xsl:text>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="body//def-list">
+    <dl>
+      <xsl:for-each select="def-item">
+        <dt>
+          <xsl:apply-templates select="term"/>
+        </dt>
+        <dd>
+          <xsl:apply-templates select="def"/>
+        </dd>
+      </xsl:for-each>
+    </dl>
+  </xsl:template>
+
+  <xsl:template match="def-item//p">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="def-item//named-content">
+    <span class="{@content-type}">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="def-item//sup | def-item//sub | def-item//em | def-item//strong">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="term">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="def">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+
 </xsl:stylesheet>

--- a/src/main/resources/peer-review-transform.xsl
+++ b/src/main/resources/peer-review-transform.xsl
@@ -217,6 +217,12 @@
        date is referenced directly in revision #0 block --> 
   <xsl:template match="article-received-date" />
 
+  <xsl:template match="bold">
+    <strong>
+      <xsl:apply-templates/>
+    </strong>
+  </xsl:template>
+
   <xsl:template match="italic">
     <em>
       <xsl:apply-templates/>

--- a/src/main/resources/peer-review-transform.xsl
+++ b/src/main/resources/peer-review-transform.xsl
@@ -240,6 +240,12 @@
       <xsl:value-of select="text()" />
     </a>
   </xsl:template>
+
+  <xsl:template match="email">
+    <a href="mailto:{.}">
+      <xsl:apply-templates/>
+    </a>
+  </xsl:template>
   
   <xsl:template match="named-content" />
 

--- a/src/main/resources/peer-review-transform.xsl
+++ b/src/main/resources/peer-review-transform.xsl
@@ -191,17 +191,47 @@
   </xsl:template>
   
   <xsl:template match="list">
-    <ul>
-      <xsl:apply-templates />
-    </ul>
+    <xsl:if test="title">
+      <h5><xsl:value-of select="title"/></h5>
+    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="@list-type='bullet'">
+        <ul class="bulleted">
+          <xsl:apply-templates/>
+        </ul>
+      </xsl:when>
+      <xsl:otherwise>
+        <ol class="{@list-type}">
+          <xsl:apply-templates/>
+        </ol>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
-  
+
   <xsl:template match="list-item">
     <li>
-      <xsl:copy-of select="node()" />
+      <xsl:if test="../@prefix-word">
+        <xsl:value-of select="../@prefix-word"/>
+        <xsl:text> </xsl:text>
+      </xsl:if>
+      <xsl:apply-templates/>
     </li>
   </xsl:template>
-  
+
+  <xsl:template match="list-item/label">
+    <span class="list-label">
+      <xsl:apply-templates/>
+      <xsl:text>. </xsl:text>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="list-item/p">
+    <xsl:apply-templates/>
+    <xsl:if test="following-sibling::p">
+      <br/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="ext-link">
     <a>
       <xsl:attribute name="href">
@@ -248,12 +278,10 @@
   </xsl:template>
 
   <xsl:template match="disp-quote">
-    <xsl:call-template name="newline1"/>
     <blockquote>
       <xsl:call-template name="assign-id"/>
       <xsl:apply-templates/>
     </blockquote>
-    <xsl:call-template name="newline1"/>
   </xsl:template>
 
   <xsl:template name="assign-id">
@@ -262,10 +290,6 @@
         <xsl:value-of select="@id"/>
       </xsl:attribute>
     </xsl:if>
-  </xsl:template>
-
-  <xsl:template name="newline1">
-    <xsl:text>&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="sub">
@@ -278,25 +302,6 @@
     <sup>
       <xsl:apply-templates/>
     </sup>
-  </xsl:template>
-
-  <xsl:template match="list-item">
-    <xsl:call-template name="newline1"/>
-    <li>
-      <xsl:if test="../@prefix-word">
-        <xsl:value-of select="../@prefix-word"/>
-        <xsl:text> </xsl:text>
-      </xsl:if>
-      <xsl:apply-templates/>
-    </li>
-    <xsl:call-template name="newline1"/>
-  </xsl:template>
-
-  <xsl:template match="list-item/label">
-    <span class="list-label">
-      <xsl:apply-templates/>
-      <xsl:text>. </xsl:text>
-    </span>
   </xsl:template>
 
   <xsl:template match="body//def-list">

--- a/src/main/resources/peer-review-transform.xsl
+++ b/src/main/resources/peer-review-transform.xsl
@@ -208,7 +208,6 @@
         <xsl:value-of select="@xlink:href" />
       </xsl:attribute>
       <xsl:value-of select="text()" />
-      &gt;
     </a>
   </xsl:template>
   

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_peer-review.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_peer-review.scss
@@ -43,3 +43,14 @@
 .peer-review-accordion-content {
   display: none;
 }
+span.underline {
+  text-decoration: underline;
+}
+
+span.strike {
+  text-decoration: line-through;
+}
+
+.monospace {
+  font-family: $font-face-monospace;
+}

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_peer-review.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_peer-review.scss
@@ -43,14 +43,12 @@
 .peer-review-accordion-content {
   display: none;
 }
-span.underline {
+.underline {
   text-decoration: underline;
 }
-
-span.strike {
+.strike {
   text-decoration: line-through;
 }
-
 .monospace {
   font-family: $font-face-monospace;
 }

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/base.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/base.css
@@ -57,6 +57,18 @@ small {
   font-size: 80%;
 }
 
+.underline {
+  text-decoration: underline;
+}
+
+.strike {
+  text-decoration: line-through;
+}
+
+.monospace {
+  font-family: "Courier New", Courier, monospace;
+}
+
 sub,
 sup {
   font-size: 75%;

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/interface.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/interface.css
@@ -161,11 +161,11 @@
   list-style: disc inside none;
 }
 
-.bulletlist {
+.bulleted {
   list-style: disc inside;
 }
 
-.bulletlist li {
+.bulleted li {
   line-height: 1.45rem;
   margin-bottom: 1.25em;
 }

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
@@ -107,14 +107,14 @@
   text-decoration: underline;
 }
 
-span.underline {
+.underline {
   text-decoration: underline;
 }
 
-span.strike {
+.strike {
   text-decoration: line-through;
 }
 
 .monospace {
-  font-family: $font-face-monospace;
+  font-family: "Courier New", Courier, monospace;
 }

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
@@ -106,15 +106,3 @@
   font-weight: 600;
   text-decoration: underline;
 }
-
-.underline {
-  text-decoration: underline;
-}
-
-.strike {
-  text-decoration: line-through;
-}
-
-.monospace {
-  font-family: "Courier New", Courier, monospace;
-}

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
@@ -34,6 +34,10 @@
   color: #222;
 }
 
+.letter__body a {
+  word-wrap: anywhere;
+}
+
 .letter__label {
   display: inline-block;
 }

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/peer-review.css
@@ -106,3 +106,15 @@
   font-weight: 600;
   text-decoration: underline;
 }
+
+span.underline {
+  text-decoration: underline;
+}
+
+span.strike {
+  text-decoration: line-through;
+}
+
+.monospace {
+  font-family: $font-face-monospace;
+}

--- a/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/mobile/xform/article-transform.xsl
@@ -1384,7 +1384,7 @@
     <xsl:choose>
       <xsl:when test="@list-type='bullet'">
         <xsl:call-template name="newline1"/>
-        <ul class="bulletlist">
+        <ul class="bulleted">
           <xsl:call-template name="newline1"/>
           <xsl:apply-templates/>
           <xsl:call-template name="newline1"/>


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-864

## What this PR does:
Presents a MVP set of JATS tags on the Peer Review page.

## Developer Notes
The peer review XSL continues to be device-agnostic thus avoiding separate transforms for mobile and desktop. The intent is to handle any differences in CSS. To this end 77b9b9233637a5241aa3c9e72a015bf0009abca0 reconciles a needless difference between the mobile and desktop article transforms with regards to the class applied to a `<ul>`.

[See the ticket](https://jira.plos.org/jira/browse/AMBR-864?focusedCommentId=247607&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-247607) For a comparison of the article and peer review pages.

I've tested in a container with wombat referring to the dev rhino.  Example URL:
http://172.24.0.2:8080/DesktopPlosOne/article/peerReview?id=10.1371/journal.pone.0207232

If you want to ingest and test with a local rhino I can provide an ingestible zip for the above article.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
