### PR TITLE
AMBR-978 Only display Mendeley results in signpost

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/signposts.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/signposts.js
@@ -62,6 +62,7 @@ var Signposts;
         data.sources
         var citation_used = "Scopus";
         var citation_count = 0;
+        var saved_count;
         if (!_.isUndefined(data.sources)) {
           var scopus = _.findWhere(data.sources, {name: 'scopus'});
           var crossref = _.findWhere(data.sources, {name: 'crossref'});
@@ -72,11 +73,12 @@ var Signposts;
             citation_used = "Crossref";
             citation_count = crossref.metrics.total;
           }
+          saved_count = _.findWhere(data.sources, {name: 'mendeley'}).metrics.total;
         }
 
         var template = _.template($('#signpostsTemplate').html());
         var templateData = {
-          saveCount: data.saved,
+          saveCount: saved_count,
           citationCount: citation_count,
           shareCount: data.discussed,
           viewCount: getPmcViewsAndDownloads(articleData) + counter_views


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-978

## What this PR does:

Only displays mendeley saves in the "signpost" data, to align with data in the metrics page.

Example. On dev, we see (https://journals-dev.plos.org/ploscompbiol/article/metrics?id=10.1371/journal.pcbi.1000112)

![image](https://user-images.githubusercontent.com/22718/60464819-69c79300-9c04-11e9-9a49-9c42fee8a5d4.png)

But on the signpost:
![image](https://user-images.githubusercontent.com/22718/60464853-82d04400-9c04-11e9-868e-7e439b9a13f7.png)

With this code, we see on the signpost:

![image](https://user-images.githubusercontent.com/22718/60464753-51f00f00-9c04-11e9-9e66-deecfd230d1c.png)

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
