### PR TITLE
Ambr 1033 branded citations

### DIFF
--- a/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ArticleMetadata {
@@ -500,6 +501,7 @@ public class ArticleMetadata {
    * Types of related articles that get special display handling.
    */
   private static enum AmendmentType {
+    UPDATE("updated-article"),
     CORRECTION("corrected-article"),
     EOC("object-of-concern"),
     RETRACTION("retracted-article");
@@ -531,6 +533,9 @@ public class ArticleMetadata {
     return Optional.ofNullable(amendmentType);
   }
 
+  //  These amendment types display the full body of the related article. Otherwise just show the citation.
+  private static Set<AmendmentType> FULL_BODY_AMENDMENTS = EnumSet.of(AmendmentType.EOC, AmendmentType.RETRACTION);
+
   /**
    * @param site           the site being rendered
    * @param relatedArticle a relationship to an amendment to this article
@@ -555,8 +560,7 @@ public class ArticleMetadata {
 
     amendment.putAll(authors);
 
-    // Display the body only on non-correction amendments. Would be better if this were configurable per theme.
-    if (amendmentType != AmendmentType.CORRECTION) {
+    if (FULL_BODY_AMENDMENTS.contains(amendmentType)) {
       String body;
       try {
         body = getAmendmentBody(amendmentId);

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
@@ -70,4 +70,9 @@
   <#if amendmentGroup.type == 'retraction'>
     <@amendmentNotice amendmentGroup "Retraction" "View retraction" amendmentGroup_index />
   </#if>
+  <#if amendmentGroup.type == 'update'>
+    <@amendmentNotice amendmentGroup,
+    (amendmentGroup.amendments?size == 1)?string("Update", "Updates"),
+    "View update" amendmentGroup_index />
+  </#if>
 </#list>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
@@ -58,21 +58,14 @@
 </div>
 </#macro>
 
+<#-- Supports custom singular and plural titles for amendment types -->
+<#assign customStrings = {"eoc": ["Expression of Concern", "Expressions of Concern"]}>
 <#list amendments as amendmentGroup>
-  <#if amendmentGroup.type == 'correction'>
-    <@amendmentNotice amendmentGroup,
-    (amendmentGroup.amendments?size == 1)?string("Correction", "Corrections"),
-    "View correction" amendmentGroup_index />
-  </#if>
-  <#if amendmentGroup.type == 'eoc'>
-    <@amendmentNotice amendmentGroup "Expression of Concern" "View expression of concern" amendmentGroup_index />
-  </#if>
-  <#if amendmentGroup.type == 'retraction'>
-    <@amendmentNotice amendmentGroup "Retraction" "View retraction" amendmentGroup_index />
-  </#if>
-  <#if amendmentGroup.type == 'update'>
-    <@amendmentNotice amendmentGroup,
-    (amendmentGroup.amendments?size == 1)?string("Update", "Updates"),
-    "View update" amendmentGroup_index />
-  </#if>
+  <#assign type = amendmentGroup.type>
+  <#assign typeStrings = customStrings[type]![type?capitalize, "${type?capitalize}s"]>
+  <#assign singular = typeStrings[0]>
+  <#assign plural = typeStrings[1]>
+  <#assign title = (amendmentGroup.amendments?size == 1)?string(singular, plural)>
+  <#assign link_text = "View ${singular?lower_case}">
+  <@amendmentNotice amendmentGroup, title, link_text, amendmentGroup_index />
 </#list>

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/_utilities.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/_utilities.scss
@@ -223,6 +223,10 @@ example | extension
     }
   }
 
+  .amendment {
+    background-color: $shade3;
+  }
+
   %brand-shaded-blocks {
 
     &:first-child,

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article-body.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article-body.scss
@@ -21,13 +21,6 @@ $line-height-large: ($line-height * 2);
 $line-height-medium: ($line-height * 1.5);
 $line-height-small: ($line-height * .5);
 
-// callout is for blockquotes.
-@mixin callout($clr-body: $off-white) {
-  padding: $line-height $pad-default 1px $pad-default; //TODO -  why is this 1px - not sure but its the only thing that seems to work
-  background: $clr-body;
-  margin-bottom: $line-height;
-}
-
 // this is the amount we want to offset the target so it doesn't butt up against the top of the window OR the floating header.
 .article-content {
   ol.references {
@@ -98,22 +91,10 @@ $line-height-small: ($line-height * .5);
     }
   }
 
-  .callout-standard,
-  .box {
-    @include callout();
-    background: $off-white;
-    h2:first-of-type,
-    h3:first-of-type {
-      margin-top: 0;
-    }  //TODO - abstract a little
-  }
-
-  .callout-alert {
-    @include callout($clr-warning-bg);
-  }
-
   .amendment {
-    margin-bottom: $line-height-medium;
+//   default background color is journal-branded via the `brandcolor` mixin
+    padding: $line-height $pad-default 1px $pad-default;
+    margin-bottom: $line-height;
     position: relative;
 
     a.info-link {
@@ -149,26 +130,29 @@ $line-height-small: ($line-height * .5);
   .amendment-eoc,
   .amendment-retraction,
   .amendment-uncorrected-proof {
-    @extend .callout-alert;
+    background: $clr-warning-bg;
     h2 {
       color: $clr-warning;
       margin-top: 0;
       &:before {
-        //TODO - make this a mixin? do we adjust line-height on all icons?
         @extend .icon-alert;
         font-size: $txt-size-medium-large;
       }
     }
   }
 
+  .box,
   .amendment-correction {
-    @extend .callout-standard;
-
+    background: $off-white;
     h2 {
       &:before {
         content: '';
         @extend .icon-correction;
       }
+    }
+    h2:first-of-type,
+    h3:first-of-type {
+      margin-top: 0;
     }
   }
 


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-1033

## What this PR does:
Amendments (like Corrections, Retractions, and now Update Article) are displayed in the top center of the related article.  ex: https://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.1001786

This change gives the amendment a journal-branded background color.  Specific amendment types can override the background color via CSS, as Correction, Retraction, and EOC continue to do.


## Developer Notes
I removed a couple of "callout" mixins that were adding complexity where IMO it wasn't needed.

# Code Author Tasks:

> This list should be finished before code review:
- [x] Ticket AC is updated with any decisions made in comments or side conversations.
- [x] Testing or PO Accept notes that will assist the tester, Product Owner or reviewer are set in the ticket.

# Code Reviewer Tasks
- [ ] I read through the JIRA ticket's AC before doing the rest of the review.
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
