### PR TITLE
AMBR-881 Remove rhombat dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <org.springframework-version>4.3.14.RELEASE</org.springframework-version>
     <org.springsecurity-version>4.1.5.RELEASE</org.springsecurity-version>
     <org.slf4j-version>1.6.6</org.slf4j-version>
-    <rhombat.version>1.0.1</rhombat.version>
     <maven.tomcat.uriEncoding>UTF-8</maven.tomcat.uriEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
@@ -79,11 +78,6 @@
   </pluginRepositories>
 
   <dependencies>
-    <dependency>
-      <groupId>org.ambraproject</groupId>
-      <artifactId>rhombat</artifactId>
-      <version>${rhombat.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.plos</groupId>
       <artifactId>ned-client</artifactId>
@@ -183,6 +177,11 @@
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>net.spy</groupId>
+      <artifactId>spymemcached</artifactId>
+      <version>2.12.3</version>
     </dependency>
 
     <!-- Spring -->

--- a/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
+++ b/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
@@ -1,0 +1,286 @@
+/* PLEASE READ */
+/* This is not packaged for maven so we include it here. */
+/* https://github.com/google/gson/blob/master/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java */
+
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.typeadapters;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
+  private final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+  @Override
+  public void write(JsonWriter out, Date date) throws IOException {
+    if (date == null) {
+      out.nullValue();
+    } else {
+      String value = format(date, true, UTC_TIME_ZONE);
+      out.value(value);
+    }
+  }
+
+  @Override
+  public Date read(JsonReader in) throws IOException {
+    try {
+      switch (in.peek()) {
+      case NULL:
+        in.nextNull();
+        return null;
+      default:
+        String date = in.nextString();
+        // Instead of using iso8601Format.parse(value), we use Jackson's date parsing
+        // This is because Android doesn't support XXX because it is JDK 1.6
+        return parse(date, new ParsePosition(0));
+      }
+    } catch (ParseException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  // Date parsing code from Jackson databind ISO8601Utils.java
+  // https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java
+  private static final String GMT_ID = "GMT";
+
+  /**
+   * Format date into yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   *
+   * @param date the date to format
+   * @param millis true to include millis precision otherwise false
+   * @param tz timezone to use for the formatting (GMT will produce 'Z')
+   * @return the date formatted as yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   */
+  private static String format(Date date, boolean millis, TimeZone tz) {
+      Calendar calendar = new GregorianCalendar(tz, Locale.US);
+      calendar.setTime(date);
+
+      // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
+      int capacity = "yyyy-MM-ddThh:mm:ss".length();
+      capacity += millis ? ".sss".length() : 0;
+      capacity += tz.getRawOffset() == 0 ? "Z".length() : "+hh:mm".length();
+      StringBuilder formatted = new StringBuilder(capacity);
+
+      padInt(formatted, calendar.get(Calendar.YEAR), "yyyy".length());
+      formatted.append('-');
+      padInt(formatted, calendar.get(Calendar.MONTH) + 1, "MM".length());
+      formatted.append('-');
+      padInt(formatted, calendar.get(Calendar.DAY_OF_MONTH), "dd".length());
+      formatted.append('T');
+      padInt(formatted, calendar.get(Calendar.HOUR_OF_DAY), "hh".length());
+      formatted.append(':');
+      padInt(formatted, calendar.get(Calendar.MINUTE), "mm".length());
+      formatted.append(':');
+      padInt(formatted, calendar.get(Calendar.SECOND), "ss".length());
+      if (millis) {
+          formatted.append('.');
+          padInt(formatted, calendar.get(Calendar.MILLISECOND), "sss".length());
+      }
+
+      int offset = tz.getOffset(calendar.getTimeInMillis());
+      if (offset != 0) {
+          int hours = Math.abs((offset / (60 * 1000)) / 60);
+          int minutes = Math.abs((offset / (60 * 1000)) % 60);
+          formatted.append(offset < 0 ? '-' : '+');
+          padInt(formatted, hours, "hh".length());
+          formatted.append(':');
+          padInt(formatted, minutes, "mm".length());
+      } else {
+          formatted.append('Z');
+      }
+
+      return formatted.toString();
+  }
+  /**
+   * Zero pad a number to a specified length
+   *
+   * @param buffer buffer to use for padding
+   * @param value the integer value to pad if necessary.
+   * @param length the length of the string we should zero pad
+   */
+  private static void padInt(StringBuilder buffer, int value, int length) {
+      String strValue = Integer.toString(value);
+      for (int i = length - strValue.length(); i > 0; i--) {
+          buffer.append('0');
+      }
+      buffer.append(strValue);
+  }
+
+  /**
+   * Parse a date from ISO-8601 formatted string. It expects a format
+   * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh:mm]]
+   *
+   * @param date ISO string to parse in the appropriate format.
+   * @param pos The position to start parsing from, updated to where parsing stopped.
+   * @return the parsed date
+   * @throws ParseException if the date is not in the appropriate format
+   */
+  private static Date parse(String date, ParsePosition pos) throws ParseException {
+    Exception fail = null;
+    try {
+      int offset = pos.getIndex();
+
+      // extract year
+      int year = parseInt(date, offset, offset += 4);
+      if (checkOffset(date, offset, '-')) {
+        offset += 1;
+      }
+
+      // extract month
+      int month = parseInt(date, offset, offset += 2);
+      if (checkOffset(date, offset, '-')) {
+        offset += 1;
+      }
+
+      // extract day
+      int day = parseInt(date, offset, offset += 2);
+      // default time value
+      int hour = 0;
+      int minutes = 0;
+      int seconds = 0;
+      int milliseconds = 0; // always use 0 otherwise returned date will include millis of current time
+      if (checkOffset(date, offset, 'T')) {
+
+        // extract hours, minutes, seconds and milliseconds
+        hour = parseInt(date, offset += 1, offset += 2);
+        if (checkOffset(date, offset, ':')) {
+          offset += 1;
+        }
+
+        minutes = parseInt(date, offset, offset += 2);
+        if (checkOffset(date, offset, ':')) {
+          offset += 1;
+        }
+        // second and milliseconds can be optional
+        if (date.length() > offset) {
+          char c = date.charAt(offset);
+          if (c != 'Z' && c != '+' && c != '-') {
+            seconds = parseInt(date, offset, offset += 2);
+            // milliseconds can be optional in the format
+            if (checkOffset(date, offset, '.')) {
+              milliseconds = parseInt(date, offset += 1, offset += 3);
+            }
+          }
+        }
+      }
+
+      // extract timezone
+      String timezoneId;
+      if (date.length() <= offset) {
+        throw new IllegalArgumentException("No time zone indicator");
+      }
+      char timezoneIndicator = date.charAt(offset);
+      if (timezoneIndicator == '+' || timezoneIndicator == '-') {
+        String timezoneOffset = date.substring(offset);
+        timezoneId = GMT_ID + timezoneOffset;
+        offset += timezoneOffset.length();
+      } else if (timezoneIndicator == 'Z') {
+        timezoneId = GMT_ID;
+        offset += 1;
+      } else {
+        throw new IndexOutOfBoundsException("Invalid time zone indicator " + timezoneIndicator);
+      }
+
+      TimeZone timezone = TimeZone.getTimeZone(timezoneId);
+      if (!timezone.getID().equals(timezoneId)) {
+        throw new IndexOutOfBoundsException();
+      }
+
+      Calendar calendar = new GregorianCalendar(timezone);
+      calendar.setLenient(false);
+      calendar.set(Calendar.YEAR, year);
+      calendar.set(Calendar.MONTH, month - 1);
+      calendar.set(Calendar.DAY_OF_MONTH, day);
+      calendar.set(Calendar.HOUR_OF_DAY, hour);
+      calendar.set(Calendar.MINUTE, minutes);
+      calendar.set(Calendar.SECOND, seconds);
+      calendar.set(Calendar.MILLISECOND, milliseconds);
+
+      pos.setIndex(offset);
+      return calendar.getTime();
+      // If we get a ParseException it'll already have the right message/offset.
+      // Other exception types can convert here.
+    } catch (IndexOutOfBoundsException e) {
+      fail = e;
+    } catch (NumberFormatException e) {
+      fail = e;
+    } catch (IllegalArgumentException e) {
+      fail = e;
+    }
+    String input = (date == null) ? null : ("'" + date + "'");
+    throw new ParseException("Failed to parse date [" + input + "]: " + fail.getMessage(), pos.getIndex());
+  }
+
+  /**
+   * Check if the expected character exist at the given offset in the value.
+   *
+   * @param value the string to check at the specified offset
+   * @param offset the offset to look for the expected character
+   * @param expected the expected character
+   * @return true if the expected character exist at the given offset
+   */
+  private static boolean checkOffset(String value, int offset, char expected) {
+    return (offset < value.length()) && (value.charAt(offset) == expected);
+  }
+
+  /**
+   * Parse an integer located between 2 given offsets in a string
+   *
+   * @param value the string to parse
+   * @param beginIndex the start index for the integer in the string
+   * @param endIndex the end index for the integer in the string
+   * @return the int
+   * @throws NumberFormatException if the value is not a number
+   */
+  private static int parseInt(String value, int beginIndex, int endIndex) throws NumberFormatException {
+    if (beginIndex < 0 || endIndex > value.length() || beginIndex > endIndex) {
+      throw new NumberFormatException(value);
+    }
+    // use same logic as in Integer.parseInt() but less generic we're not supporting negative values
+    int i = beginIndex;
+    int result = 0;
+    int digit;
+    if (i < endIndex) {
+      digit = Character.digit(value.charAt(i++), 10);
+      if (digit < 0) {
+        throw new NumberFormatException("Invalid number: " + value);
+      }
+      result = -digit;
+    }
+    while (i < endIndex) {
+      digit = Character.digit(value.charAt(i++), 10);
+      if (digit < 0) {
+        throw new NumberFormatException("Invalid number: " + value);
+      }
+      result *= 10;
+      result -= digit;
+    }
+    return -result;
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/cache/Cache.java
+++ b/src/main/java/org/ambraproject/wombat/cache/Cache.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.cache;
+
+import java.io.Serializable;
+
+/**
+ * Interface for a simple key-value cache.  Keys are always Strings while values
+ * can be any type that implements {@link java.io.Serializable}.
+ */
+public interface Cache {
+
+  /**
+   * Attempts to retrieve a value from the cache.
+   *
+   * @param key the cache key
+   * @param <T> type of the value
+   * @return the value if it is found in the cache, or null if it is not
+   */
+  <T extends Serializable> T get(String key);
+
+  /**
+   * Stores a value in the cache.  The inserted value may have a TTL that is implementation-dependent.
+   * Use the three-argument put method if you want to define the TTL.
+   *
+   * @param key cache key
+   * @param value object to store
+   */
+  <T extends Serializable> void put(String key, T value);
+
+  /**
+   * Stores a value in the cache.
+   *
+   * @param key cache key
+   * @param value object to store
+   * @param ttl cache TTL for the value, in seconds
+   */
+  <T extends Serializable> void put(String key, T value, int ttl);
+
+  /**
+   * Removes a key/value mapping from the cache, if it exists.
+   *
+   * @param key cache key
+   */
+  void remove(String key);
+}

--- a/src/main/java/org/ambraproject/wombat/cache/GuavaCache.java
+++ b/src/main/java/org/ambraproject/wombat/cache/GuavaCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.cache;
+
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.TimeUnit;
+import com.google.common.cache.CacheLoader;
+import java.io.Serializable;
+
+public class GuavaCache implements Cache {
+  private static final Logger log = LoggerFactory.getLogger(GuavaCache.class);
+  com.google.common.cache.Cache<String, Object> cache;
+
+  public GuavaCache(int maximumSize) {
+    cache = CacheBuilder.newBuilder().maximumSize(maximumSize).build();
+  }
+
+  public GuavaCache() {
+    this(1000);
+  }
+
+  public void remove(String key) {
+    cache.invalidate(key);
+  }
+
+  public <T extends Serializable> void put(String key, T value, int timeout) {
+    put(key, value);
+  }
+
+  public <T extends Serializable> void put(String key, T value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public <T extends Serializable> T get(String key) {
+    return (T) cache.getIfPresent(key);
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/cache/MemcacheClient.java
+++ b/src/main/java/org/ambraproject/wombat/cache/MemcacheClient.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.cache;
+
+import net.spy.memcached.MemcachedClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Simple wrapper around the spymemcached API that implements {@link Cache}.
+ */
+public class MemcacheClient implements Cache {
+
+  private static final Logger log = LoggerFactory.getLogger(MemcacheClient.class);
+
+  /**
+   * Timeout for cache reads, in milliseconds.  If memcached doesn't respond within
+   * this length of time, gets will return null.
+   */
+  // TODO: consider making this configurable.
+  private static final int GET_TIMEOUT = 1000;
+
+  private final String host;
+
+  private final int port;
+
+  private final String appPrefix;
+
+  private final int defaultTtl;
+
+  private MemcachedClient client;
+
+  /**
+   * Constructor.
+   *
+   * @param host memcached host
+   * @param port memcached port
+   * @param appPrefix prefix that will be used for all cache keys.  This should be
+   *     a String that is shared by all application servers of a certain type.
+   * @param defaultTtl the default cache TTL to use for the two-argument put method.
+   *     This can be overridden by calling the three-argument put.
+   */
+  public MemcacheClient(String host, int port, String appPrefix, int defaultTtl) {
+    this.host = host;
+    this.port = port;
+    this.appPrefix = appPrefix;
+    this.defaultTtl = defaultTtl;
+  }
+
+  /**
+   * Connects to the memcached server.  This method must be called at least once
+   * before the cache can be used.  It is OK to call it multiple times (it will
+   * only connect the first time it's called).
+   *
+   * @throws IOException
+   */
+  public synchronized void connect() throws IOException {
+    if (client == null) {
+
+      // TODO: in the future we might want to support multiple memcached servers.
+      // See http://code.google.com/p/spymemcached/wiki/Examples for how to do this.
+      client = new MemcachedClient(new InetSocketAddress(host, port));
+    }
+  }
+
+  /**
+   * Attempts to retrieve a value from the cache.  If the server does not respond
+   * within GET_TIMEOUT milliseconds, this method may return null, even if the key
+   * was actually in the cache.
+   */
+  @Override
+  public <T extends Serializable> T get(String key) {
+    key = buildKey(key);
+    Object result = null;
+    Future<Object> future = client.asyncGet(key);
+    try {
+      result = future.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+
+      // TODO: this makes me nervous.  The idea is that we don't want to block
+      // indefinitely for occasional memcached hiccups.  However, if memcached
+      // is down completely, we probably want to throw an exception here instead
+      // of just log.  One idea would be to keep track of the number of timeouts,
+      // and if it exceeds a certain number per time interval, throw an exception
+      // instead of logging here.
+      log.warn("Memcache lookup timed out for key " + key);
+      future.cancel(false);
+    } catch (InterruptedException ie) {
+      throw new RuntimeException(ie);
+    } catch (ExecutionException ee) {
+      throw new RuntimeException(ee);
+    }
+    return (T) result;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T extends Serializable> void put(String key, T value) {
+    put(key, value, defaultTtl);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T extends Serializable> void put(String key, T value, int timeout) {
+    client.set(buildKey(key), timeout, value);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void remove(String key) {
+    client.delete(key);
+  }
+
+  private String buildKey(String subKey) {
+    return new StringBuilder(appPrefix).append(':').append(subKey).toString();
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/cache/NullCache.java
+++ b/src/main/java/org/ambraproject/wombat/cache/NullCache.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.cache;
+
+import java.io.Serializable;
+
+/**
+ * An implementation of {@link Cache} that doesn't cache anything, and always returns null.
+ */
+public class NullCache implements Cache {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T extends Serializable> T get(String key) {
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T extends Serializable> void put(String key, T value) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T extends Serializable> void put(String key, T value, int timeout) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void remove(String key) {}
+}

--- a/src/main/java/org/ambraproject/wombat/config/RootConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/RootConfiguration.java
@@ -22,14 +22,23 @@
 
 package org.ambraproject.wombat.config;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Date;
+
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
-import org.ambraproject.rhombat.cache.Cache;
-import org.ambraproject.rhombat.cache.MemcacheClient;
-import org.ambraproject.rhombat.cache.NullCache;
-import org.ambraproject.rhombat.gson.Iso8601DateAdapter;
+import com.google.gson.typeadapters.UtcDateTypeAdapter;
+
+import org.ambraproject.wombat.cache.Cache;
+import org.ambraproject.wombat.cache.MemcacheClient;
+import org.ambraproject.wombat.cache.NullCache;
 import org.ambraproject.wombat.config.yaml.IgnoreMissingPropertyConstructor;
 import org.ambraproject.wombat.service.remote.ArticleApi;
 import org.ambraproject.wombat.service.remote.ArticleApiImpl;
@@ -49,14 +58,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.util.Date;
 
 @Configuration
 public class RootConfiguration {
@@ -115,7 +116,7 @@ public class RootConfiguration {
   public Gson gson() {
     GsonBuilder builder = new GsonBuilder();
     builder.setPrettyPrinting();
-    builder.registerTypeAdapter(Date.class, new Iso8601DateAdapter());
+    builder.registerTypeAdapter(Date.class, new UtcDateTypeAdapter());
     builder.registerTypeAdapter(org.joda.time.LocalDate.class, JodaTimeLocalDateAdapter.INSTANCE);
     return builder.create();
   }

--- a/src/main/java/org/ambraproject/wombat/service/AssetServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/AssetServiceImpl.java
@@ -29,7 +29,7 @@ import com.google.common.util.concurrent.Striped;
 import com.yahoo.platform.yui.compressor.CssCompressor;
 import com.yahoo.platform.yui.compressor.JavaScriptCompressor;
 
-import org.ambraproject.rhombat.cache.Cache;
+import org.ambraproject.wombat.cache.Cache;
 import org.ambraproject.wombat.config.RuntimeConfiguration;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.config.theme.Theme;

--- a/src/main/java/org/ambraproject/wombat/service/BrowseTaxonomyServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/BrowseTaxonomyServiceImpl.java
@@ -21,7 +21,7 @@
  */
 package org.ambraproject.wombat.service;
 
-import org.ambraproject.rhombat.cache.Cache;
+import org.ambraproject.wombat.cache.Cache;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.model.TaxonomyCountTable;
 import org.ambraproject.wombat.model.TaxonomyGraph;

--- a/src/main/java/org/ambraproject/wombat/service/RecentArticleServiceImpl.java
+++ b/src/main/java/org/ambraproject/wombat/service/RecentArticleServiceImpl.java
@@ -24,7 +24,7 @@ package org.ambraproject.wombat.service;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.ambraproject.rhombat.cache.Cache;
+import org.ambraproject.wombat.cache.Cache;
 import org.ambraproject.wombat.config.site.Site;
 import org.ambraproject.wombat.service.remote.ArticleSearchQuery;
 import org.ambraproject.wombat.service.remote.SolrSearchApi;

--- a/src/main/java/org/ambraproject/wombat/util/CacheUtil.java
+++ b/src/main/java/org/ambraproject/wombat/util/CacheUtil.java
@@ -22,7 +22,7 @@
 
 package org.ambraproject.wombat.util;
 
-import org.ambraproject.rhombat.cache.Cache;
+import org.ambraproject.wombat.cache.Cache;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
+++ b/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
@@ -1,0 +1,93 @@
+/* PLEASE READ */
+/* This is not packaged for maven so we include it here. */
+/* Upstream: https://github.com/google/gson/blob/master/extras/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java */
+
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.typeadapters;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import com.google.gson.JsonParseException;
+import junit.framework.TestCase;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public final class UtcDateTypeAdapterTest extends TestCase {
+  private final Gson gson = new GsonBuilder()
+    .registerTypeAdapter(Date.class, new UtcDateTypeAdapter())
+    .create();
+
+  public void testLocalTimeZone() {
+    Date expected = new Date();
+    String json = gson.toJson(expected);
+    Date actual = gson.fromJson(json, Date.class);
+    assertEquals(expected.getTime(), actual.getTime());
+  }
+
+  public void testDifferentTimeZones() {
+    for (String timeZone : TimeZone.getAvailableIDs()) {
+      Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(timeZone));
+      Date expected = cal.getTime();
+      String json = gson.toJson(expected);
+      // System.out.println(json + ": " + timeZone);
+      Date actual = gson.fromJson(json, Date.class);
+      assertEquals(expected.getTime(), actual.getTime());
+    }
+  }
+
+  /**
+   * JDK 1.7 introduced support for XXX format to indicate UTC date. But Android is older JDK.
+   * We want to make sure that this date is parseable in Android.
+   */
+  public void testUtcDatesOnJdkBefore1_7() {
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapter(Date.class, new UtcDateTypeAdapter())
+      .create();
+    gson.fromJson("'2014-12-05T04:00:00.000Z'", Date.class);
+  }
+
+  public void testUtcWithJdk7Default() {
+    Date expected = new Date();
+    SimpleDateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
+    iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
+    String expectedJson = "\"" + iso8601Format.format(expected) + "\"";
+    String actualJson = gson.toJson(expected);
+    assertEquals(expectedJson, actualJson);
+    Date actual = gson.fromJson(expectedJson, Date.class);
+    assertEquals(expected.getTime(), actual.getTime());
+  }
+
+  public void testNullDateSerialization() {
+    String json = gson.toJson(null, Date.class);
+    assertEquals("null", json);
+  }
+
+  public void testWellFormedParseException() {
+    try {
+      gson.fromJson("2017-06-20T14:32:30", Date.class);
+      fail("No exception");
+    } catch (JsonParseException exe) {
+      assertEquals(exe.getMessage(), "java.text.ParseException: Failed to parse date ['2017-06-20T14']: 2017-06-20T14");
+    }
+  }
+}

--- a/src/test/java/org/ambraproject/wombat/cache/GuavaCacheTest.java
+++ b/src/test/java/org/ambraproject/wombat/cache/GuavaCacheTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class GuavaCacheTest {
+  @Test
+  public void testCacheGet() {
+    GuavaCache cache = new GuavaCache();
+    cache.put("hello", "world");
+
+    assertEquals("world", cache.get("hello"));
+  }
+
+  @Test
+  public void testCacheRemove() {
+    GuavaCache cache = new GuavaCache();
+    cache.put("hello", "world");
+    cache.remove("hello");
+    assertNull(cache.get("hello"));
+  }
+
+  @Test
+  public void testCacheEviction() {
+    GuavaCache cache = new GuavaCache(1);
+    cache.put("hello", "world");
+    cache.put("goodbye", "world");
+    assertNull(cache.get("hello"));
+    assertEquals("world", cache.get("goodbye"));
+  }
+}

--- a/src/test/java/org/ambraproject/wombat/config/TestSpringConfiguration.java
+++ b/src/test/java/org/ambraproject/wombat/config/TestSpringConfiguration.java
@@ -33,8 +33,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
-import org.ambraproject.rhombat.cache.Cache;
-import org.ambraproject.rhombat.cache.NullCache;
+import org.ambraproject.wombat.cache.Cache;
+import org.ambraproject.wombat.cache.NullCache;
 import org.ambraproject.wombat.config.site.SiteSet;
 import org.ambraproject.wombat.config.theme.TestClasspathTheme;
 import org.ambraproject.wombat.config.theme.Theme;

--- a/src/test/java/org/ambraproject/wombat/controller/ControllerTestConfiguration.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ControllerTestConfiguration.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import org.ambraproject.rhombat.gson.Iso8601DateAdapter;
+import com.google.gson.typeadapters.UtcDateTypeAdapter;
 import org.ambraproject.wombat.config.RuntimeConfiguration;
 import org.ambraproject.wombat.config.TestRuntimeConfiguration;
 import org.ambraproject.wombat.config.site.RequestMappingContextDictionary;
@@ -61,7 +61,7 @@ public class ControllerTestConfiguration {
   protected Gson gson() {
     GsonBuilder builder = new GsonBuilder();
     builder.setPrettyPrinting();
-    builder.registerTypeAdapter(Date.class, new Iso8601DateAdapter());
+    builder.registerTypeAdapter(Date.class, new UtcDateTypeAdapter());
     builder.registerTypeAdapter(org.joda.time.LocalDate.class, JodaTimeLocalDateAdapter.INSTANCE);
     return builder.create();
   }


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-881


## What this PR does:

Eliminates use of the rhombat library, which complicates builds.

- Move caching from rhombat to wombat
- Use UtcDateTypeAdapter from google
- Use DateUtils from httpclient

# Code Author Tasks:

If I used outside libraries:
- [x] License comports with our licensing (MIT preferable)
# Code Reviewer Tasks
- [x] I read through the JIRA ticket's AC before doing the rest of the review.
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket. If not practical I have seen some evidence that the code does what it says (tests have passed).

## Project or Language Specific Tasks ###
