### PR TITLE
Ambr 1064

### DIFF
--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -156,6 +156,11 @@
           This article has been retracted.
         </@amendment>
       </#if>
+      <#if amendmentGroup.type == 'update'>
+        <@amendment amendmentGroup.amendments "updated-article">
+          This article has an update.
+        </@amendment>
+      </#if>
     </#list>
 
     <#-- In articleSuffix.ftl: Close <article class="article-item"> -->

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -122,17 +122,17 @@
 
     <#include "revision/revisionNotice.ftl" />
 
-    <#macro amendment amendmentObjects amendmentType>
-      <div class="retraction red-alert">
+    <#macro amendment amendmentGroup amendmentType>
+      <div class="amendment amendment-${amendmentGroup.type}">
         <span><h5>
           <#nested/>
-          <#if amendmentObjects?size == 1>
-            <a href="article?id=${amendmentObjects[0].doi}">
+          <#if amendmentGroup.amendments?size == 1>
+            <a href="article?id=${amendmentGroup.amendments[0].doi}">
               View ${amendmentType}
             </a>
           <#else>
             View
-            <#list amendmentObjects as amendmentObject>
+            <#list amendmentGroup.amendments as amendmentObject>
               <a href="article?id=${amendmentObject.doi}">
               ${amendmentType} ${amendmentObject_index + 1}</a><#if amendmentObject_has_next>,</#if>
             </#list>
@@ -142,23 +142,23 @@
     </#macro>
     <#list amendments as amendmentGroup>
       <#if amendmentGroup.type == 'correction'>
-        <@amendment amendmentGroup.amendments "correction">
+        <@amendment amendmentGroup "correction">
           This article has been corrected.
         </@amendment>
       </#if>
       <#if amendmentGroup.type == 'eoc'>
-        <@amendment amendmentGroup.amendments "expression of concern">
+        <@amendment amendmentGroup "expression of concern">
           There is an expression of concern about this article.
         </@amendment>
       </#if>
       <#if amendmentGroup.type == 'retraction'>
-        <@amendment amendmentGroup.amendments "retraction">
+        <@amendment amendmentGroup "retraction">
           This article has been retracted.
         </@amendment>
       </#if>
       <#if amendmentGroup.type == 'update'>
-        <@amendment amendmentGroup.amendments "updated-article">
-          This article has an update.
+        <@amendment amendmentGroup "update">
+          This article has been updated.
         </@amendment>
       </#if>
     </#list>

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/interface.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/interface.css
@@ -222,6 +222,8 @@
 
 /* Alerts */
 .red-alert,
+.amendment-retraction,
+.amendment-eoc,
 .amendment-uncorrected-proof {
   background: #fce2e5;
 }
@@ -238,6 +240,10 @@
 
 .amendment-uncorrected-proof h2 {
   margin-top: 0 !important;
+}
+
+.amendment-correction {
+  background-color: #efefef;
 }
 
 /* Buttons */

--- a/src/main/webapp/WEB-INF/themes/mobile/resource/css/mobile.css
+++ b/src/main/webapp/WEB-INF/themes/mobile/resource/css/mobile.css
@@ -745,3 +745,8 @@ html:not(.positionfixed) #page-figure #site-header-container {
   margin-left: 0;
   list-style-type: none;
 }
+
+.amendment {
+  padding: 15px 10px;
+  margin-top: 20px;
+}


### PR DESCRIPTION
*JIRA issue:* https://jira.plos.org/jira/browse/AMBR-1064

*Related PRs:* 
https://github.com/PLOS/plos-themes/pull/1000

## What this PR does:
Updates the mobile themes to use journal-branded amendments unless specifically overridden, as is the case for retraction and eoc which are red and correction which is off-white.  This brings the amendment view to parity with desktop.

Also added the updated-article relationship type to the set of relationships that deserve and get a blurb at the top center of the mobile page

## Developer Notes

Very annoying that the desktop themes use SASS while the mobile just use CSS.  I do not understand it and I don't know how complex it would be to reconcile the desktop and mobile themes.
