### PR TITLE
AMBR-1074 Extract header for amendments, related sidebar

### DIFF
--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
@@ -134,7 +134,7 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         RelatedArticleType.builder()
         .setSortOrder(7)
         .setName("update-forward")
-        .setDisplayName("Update Article")
+        .setDisplayName("Update")
         .setSpecialCssName("update")
         .setHasRelation(true)
         .setAmendment(true)
@@ -142,7 +142,7 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         RelatedArticleType.builder()
         .setSortOrder(8)
         .setName("updated-article")
-        .setDisplayName("Update Article")
+        .setDisplayName("Update")
         .build(),
         RelatedArticleType.builder()
         .setSortOrder(9)

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
@@ -23,15 +23,14 @@
 <#include "citation.ftl" />
 <#list amendments as amendmentGroup>
   <div class="amendment amendment-${amendmentGroup.type.cssName} toc-section">
-  <#assign title>
-    <@pluralize count=amendmentGroup.amendments?size value=amendmentGroup.type.displayName />
-  </#assign>
+  <#assign title><#include "amendmentGroupTitle.ftl"></#assign>
+  <#assign pluralizedTitle><@pluralize count=amendmentGroup.amendments?size value=title?trim/></#assign>
   <#assign tocTitle>
-    <#t/>${title}<#if amendmentGroup.amendments?size gt 1> (${amendmentGroup.amendments?size})</#if>
+  <#t/>${pluralizedTitle}<#if amendmentGroup.amendments?size gt 1> (${amendmentGroup.amendments?size})</#if>
   </#assign>
   <a data-toc="amendment-${amendmentGroup_index?c}" title="${tocTitle}" id="amendment-${amendmentGroup_index?c}" name="amendment-${amendmentGroup_index?c}"></a>
 
-  <h2>${title}</h2>
+  <h2>${pluralizedTitle}</h2>
   <#list amendmentGroup.amendments as amendment>
     <#if amendment.body??>
       <div class="amendment-body">
@@ -52,7 +51,7 @@
           <@siteLink path="article?id=" ; path>
             <span class="link-separator"> </span>
             <a href="${path + amendment.doi}" class="amendment-link">
-              View ${amendmentGroup.type.displayName?lower_case}
+              View ${title?lower_case}
             </a>
           </@siteLink>
         </#if>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendmentGroupTitle.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendmentGroupTitle.ftl
@@ -1,0 +1,23 @@
+<#--
+  ~ Copyright (c) 2019 Public Library of Science
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a
+  ~ copy of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom the
+  ~ Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  ~ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  ~ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  ~ DEALINGS IN THE SOFTWARE.
+  -->
+
+${amendmentGroup.type.displayName}

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/relatedArticleTypeHeader.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/relatedArticleTypeHeader.ftl
@@ -1,0 +1,22 @@
+<#--
+  ~ Copyright (c) 2019 Public Library of Science
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a
+  ~ copy of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom the
+  ~ Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  ~ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  ~ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  ~ DEALINGS IN THE SOFTWARE.
+  -->
+${type.displayName}

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/relatedArticles.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/relatedArticles.ftl
@@ -25,10 +25,11 @@
     <h3><#include "relatedArticleTitle.ftl"/></h3>
     <ul class="related-articles">
       <#list relatedArticlesByType as type, articles>
+        <#assign titleDisplay><#include "relatedArticleTypeHeader.ftl"/></#assign>
         <li>
           <b>
             <#if type.hasRelation>has</#if>
-            <@pluralize count=articles?size value=type.displayName?upper_case />
+            <@pluralize count=articles?size value=titleDisplay?trim?upper_case />
             <#if type.pertainsToRelation>pertains to</#if>
           </b>
         </li>


### PR DESCRIPTION
https://jira.plos.org/jira/browse/AMBR-1074

See also: https://github.com/PLOS/plos-themes/pull/1016

To test, point your local wombat at dev rhino by editing your `wombat.yaml` config:

```
🤔 head ~/c/ambra/config/wombat.yaml 
server: http://rhino-201.soma.plos.org:8006/v2/
# URL of the server for the service API ("Rhino")
...
```

and view:

http://localhost:8080/DesktopPlosBiology/article?id=10.1371/journal.pbio.9000098
http://localhost:8080/DesktopPlosBiology/article?id=10.1371/journal.pbio.1002593
http://localhost:8080/DesktopPlosOne/article?id=10.1371/journal.pone.0212527

If you want to test the custom theme for PLOS One only (https://github.com/PLOS/plos-themes/pull/1016) the only way I was able to do this was to copy the theme `ftl` files to my local themes dir:

```
🤔 pwd
/home/egh/c/plos-themes
🤔 rsync -a code/all_devices/journals/PlosOne/ftl/article/ /home/egh/c/ambra/var/themes/code/all_devices/journals/PlosOne/ftl/article/
```

Non-PLOS One article page:
![image](https://user-images.githubusercontent.com/22718/71297852-ff351b80-2339-11ea-84b5-4f5870ccf236.png)

PLOS One article page:
![image](https://user-images.githubusercontent.com/22718/71297921-4c18f200-233a-11ea-93e7-af78c5646f24.png)
