### PR TITLE
AMBR-1069

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,12 @@
       <version>6.4.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+
     <!-- Logging -->
     <!-- We don't actually want commons-logging because it conflicts with slf4j, this is a trick to exclude it. See "Alternative 2" here: https://www.slf4j.org/faq.html#excludingJCL -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.5</version>
+        <configuration>
+          <excludes>
+            <!-- Simple autovalue classes -->
+            <exclude>org/ambraproject/wombat/model/Amendment.class</exclude>
+            <exclude>org/ambraproject/wombat/model/AmendmentGroup.class</exclude>
+            <exclude>**/AutoValue_*.class</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ArticleMetadata.java
@@ -423,9 +423,14 @@ public class ArticleMetadata {
                                      Collectors.toList()));
   }
 
-  public Map<String, ?> getAuthors() throws IOException {
-    ApiAddress authorAddress = articlePointer.asApiAddress().addToken("authors").build();
-    return factory.articleApi.requestObject(authorAddress, Map.class);
+  private Map<String, Object> getAuthors(ArticlePointer ap) throws IOException {
+    Type tt = new TypeToken<Map<String, Object>>() {}.getType();
+    ApiAddress authorAddress = ap.asApiAddress().addToken("authors").build();
+    return factory.articleApi.<Map<String, Object>> requestObject(authorAddress, tt);
+  }
+
+  public Map<String, Object> getAuthors() throws IOException {
+    return getAuthors(this.articlePointer);
   }
 
   /**
@@ -496,11 +501,11 @@ public class ArticleMetadata {
 
     ArticlePointer amendmentId;
     Map<String, Object> amendment;
-    Map<String, ?> authors;
+    Map<String, Object> authors;
     try {
       amendmentId = factory.articleResolutionService.toIngestion(RequestedDoiVersion.of(doi)); // always uses latest revision
       amendment = (Map<String, Object>) factory.articleApi.requestObject(amendmentId.asApiAddress().build(), Map.class);
-      authors = factory.articleApi.requestObject(amendmentId.asApiAddress().addToken("authors").build(), Map.class);
+      authors = getAuthors(amendmentId);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/org/ambraproject/wombat/model/Amendment.java
+++ b/src/main/java/org/ambraproject/wombat/model/Amendment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.model;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Amendment {
+  @Nullable public abstract String getBody();
+  public abstract RelatedArticle getRelatedArticle();
+  public abstract List<Map<String, Object>> getAuthors();
+  public abstract Map<String, Object> getArticleMetadata();
+  public RelatedArticleType getType() {
+    return getRelatedArticle().getType();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_Amendment.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Amendment build();
+
+    public abstract Builder setAuthors(List<Map<String, Object>> authors);
+    public abstract Builder setArticleMetadata(Map<String, Object> articleMetadata);
+    public abstract Builder setBody(String body);
+    public abstract Builder setRelatedArticle(RelatedArticle relatedArticle);
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/model/AmendmentGroup.java
+++ b/src/main/java/org/ambraproject/wombat/model/AmendmentGroup.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.wombat.model;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class AmendmentGroup {
+  public abstract RelatedArticleType getType();
+  public abstract ImmutableList<Amendment> getAmendments();
+
+  public static Builder builder() {
+    return new AutoValue_AmendmentGroup.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract AmendmentGroup build();
+    public abstract Builder setType(RelatedArticleType rat);
+    abstract ImmutableList.Builder<Amendment> amendmentsBuilder();
+    public Builder addAmendment(Amendment amendment) {
+      amendmentsBuilder().add(amendment);
+      return this;
+    }
+  }
+}

--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticle.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticle.java
@@ -42,16 +42,15 @@ public abstract class RelatedArticle {
         JsonObject jsonObject = json.getAsJsonObject();
         Integer revisionNumber = jsonObject.get("revisionNumber").getAsBigInteger().intValue();
         LocalDate publicationDate = LocalDate.parse(jsonObject.get("publicationDate").getAsString());
-        RelatedArticleType relatedArticleType =
-          RelatedArticleType.get(jsonObject.get("type").getAsString());
         Optional<String> specificUse = Optional.ofNullable(jsonObject.get("specificUse")).map(JsonElement::getAsString);
+        RelatedArticleType relatedArticleType =
+          RelatedArticleType.get(jsonObject.get("type").getAsString(), specificUse.orElse(null));
         return RelatedArticle.builder()
           .setDoi(jsonObject.get("doi").getAsString())
           .setTitle(jsonObject.get("title").getAsString())
           .setRevisionNumber(revisionNumber)
           .setPublicationDate(publicationDate)
           .setType(relatedArticleType)
-          .setSpecificUse(specificUse.orElse(null))
           .setJournal(context.deserialize(jsonObject.get("journal"), RelatedArticleJournal.class))
           .build();
     }
@@ -61,8 +60,6 @@ public abstract class RelatedArticle {
   public abstract Integer getRevisionNumber();
   public abstract String getTitle();
   public abstract RelatedArticleType getType();
-  // Optional would be better, but it is not well-supported in freemarker.
-  @Nullable public abstract String getSpecificUse();
   public abstract RelatedArticleJournal getJournal();
 
   public boolean isPublished() {
@@ -83,6 +80,5 @@ public abstract class RelatedArticle {
     public abstract Builder setRevisionNumber(Integer revisionNumber);
     public abstract Builder setPublicationDate(LocalDate date);
     public abstract Builder setJournal(RelatedArticleJournal journal);
-    public abstract Builder setSpecificUse(String specificUse);
   }
 }

--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticle.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticle.java
@@ -23,11 +23,9 @@
 package org.ambraproject.wombat.model;
 import java.lang.reflect.Type;
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.Map;
-
+import java.util.Optional;
+import javax.annotation.Nullable;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -44,13 +42,16 @@ public abstract class RelatedArticle {
         JsonObject jsonObject = json.getAsJsonObject();
         Integer revisionNumber = jsonObject.get("revisionNumber").getAsBigInteger().intValue();
         LocalDate publicationDate = LocalDate.parse(jsonObject.get("publicationDate").getAsString());
-        RelatedArticleType relatedArticleType = RelatedArticleType.get(jsonObject.get("type").getAsString());
+        RelatedArticleType relatedArticleType =
+          RelatedArticleType.get(jsonObject.get("type").getAsString());
+        Optional<String> specificUse = Optional.ofNullable(jsonObject.get("specificUse")).map(JsonElement::getAsString);
         return RelatedArticle.builder()
           .setDoi(jsonObject.get("doi").getAsString())
           .setTitle(jsonObject.get("title").getAsString())
           .setRevisionNumber(revisionNumber)
           .setPublicationDate(publicationDate)
           .setType(relatedArticleType)
+          .setSpecificUse(specificUse.orElse(null))
           .setJournal(context.deserialize(jsonObject.get("journal"), RelatedArticleJournal.class))
           .build();
     }
@@ -60,6 +61,8 @@ public abstract class RelatedArticle {
   public abstract Integer getRevisionNumber();
   public abstract String getTitle();
   public abstract RelatedArticleType getType();
+  // Optional would be better, but it is not well-supported in freemarker.
+  @Nullable public abstract String getSpecificUse();
   public abstract RelatedArticleJournal getJournal();
 
   public boolean isPublished() {
@@ -80,5 +83,6 @@ public abstract class RelatedArticle {
     public abstract Builder setRevisionNumber(Integer revisionNumber);
     public abstract Builder setPublicationDate(LocalDate date);
     public abstract Builder setJournal(RelatedArticleJournal journal);
+    public abstract Builder setSpecificUse(String specificUse);
   }
 }

--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
@@ -151,7 +151,7 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         RelatedArticleType.builder()
         .setSortOrder(7)
         .setName("update-forward")
-        .setDisplayName("Update")
+        .setDisplayName("Research Article")
         .setSpecialCssName("update")
         .setSpecificUse("registered-report-protocol")
         .setHasRelation(true)
@@ -165,7 +165,7 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         RelatedArticleType.builder()
         .setSortOrder(8)
         .setName("updated-article")
-        .setDisplayName("Registered Report Protocol")
+        .setDisplayName("Research Article")
         .setAmendment(true)
         .setSpecificUse("registered-report-protocol")
         .build(),

--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
@@ -21,19 +21,23 @@
  */
 
 package org.ambraproject.wombat.model;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.Pair;
 
 @AutoValue
 public abstract class RelatedArticleType implements Comparable<RelatedArticleType> {
+  public abstract Builder toBuilder();
   public abstract int getSortOrder();
   public abstract String getDisplayName();
   public abstract String getName();
+  // Optional would be better, but it is not well-supported in freemarker.
+  @Nullable public abstract String getSpecificUse();
 
   /**
    * Special css names that are not worth removing now. :(
@@ -73,8 +77,8 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
       .setFullBodyAmendment(false);
   }
 
-  public static RelatedArticleType get(String typeName) {
-    RelatedArticleType type = TYPEMAP.get(typeName);
+  public static RelatedArticleType get(String typeName, String specificUse) {
+    RelatedArticleType type = TYPEMAP.get(Pair.of(typeName, specificUse));
     if (type != null) {
       return type;
     } else {
@@ -83,11 +87,16 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         .setName(typeName)
         .setDisplayName(typeName)
         .setHasRelation(true)
+        .setSpecificUse(specificUse)
         .setSortOrder(100)
         .build();
     }
   }
 
+  public static RelatedArticleType get(String typeName) {
+    return RelatedArticleType.get(typeName, null);
+  }
+              
   private static ImmutableSet<RelatedArticleType> TYPESET =
     ImmutableSet
     .of(RelatedArticleType.builder()
@@ -140,10 +149,25 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         .setAmendment(true)
         .build(),
         RelatedArticleType.builder()
+        .setSortOrder(7)
+        .setName("update-forward")
+        .setDisplayName("Update")
+        .setSpecialCssName("update")
+        .setSpecificUse("registered-report-protocol")
+        .setHasRelation(true)
+        .setAmendment(true)
+        .build(),
+        RelatedArticleType.builder()
         .setSortOrder(8)
         .setName("updated-article")
         .setDisplayName("Update")
+        .build(),
+        RelatedArticleType.builder()
+        .setSortOrder(8)
+        .setName("updated-article")
+        .setDisplayName("Registered Report Protocol")
         .setAmendment(true)
+        .setSpecificUse("registered-report-protocol")
         .build(),
         RelatedArticleType.builder()
         .setSortOrder(9)
@@ -165,8 +189,8 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         );
 
   /* Map from typename to RelatedArticleType */
-  private static Map<String, RelatedArticleType> TYPEMAP = TYPESET.stream()
-      .collect(Collectors.toMap(RelatedArticleType::getName, Function.identity()));
+  private static Map<Pair<String, String>, RelatedArticleType> TYPEMAP = TYPESET.stream()
+    .collect(Collectors.toMap((rat)->Pair.of(rat.getName(), rat.getSpecificUse()), Function.identity()));
 
   @Override
   public int compareTo(RelatedArticleType that) {
@@ -184,5 +208,6 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
     public abstract Builder setAmendment(boolean amendment);
     public abstract Builder setFullBodyAmendment(boolean fullBodyAmendment);
     public abstract Builder setSpecialCssName(String specialCssName);
+    public abstract Builder setSpecificUse(String specificUse);
   }
 }

--- a/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
+++ b/src/main/java/org/ambraproject/wombat/model/RelatedArticleType.java
@@ -143,6 +143,7 @@ public abstract class RelatedArticleType implements Comparable<RelatedArticleTyp
         .setSortOrder(8)
         .setName("updated-article")
         .setDisplayName("Update")
+        .setAmendment(true)
         .build(),
         RelatedArticleType.builder()
         .setSortOrder(9)

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/amendment.ftl
@@ -39,18 +39,18 @@
     </#if>
     <div class="amendment-citation">
       <p>
-        <#if amendment.publicationDate??>
+        <#if amendment.relatedArticle.publicationDate??>
           <span class="amendment-date">
-            <@formatJsonDate date="${amendment.publicationDate}" format="d MMM yyyy" />:
+            <@formatJsonDate date="${amendment.relatedArticle.publicationDate}" format="d MMM yyyy" />:
           </span>
         </#if>
 
-        <@displayCitation amendment />
+        <@displayCitation amendment.articleMetadata amendment.authors />
 
-        <#if amendment.doi??>
+        <#if amendment.relatedArticle.doi??>
           <@siteLink path="article?id=" ; path>
             <span class="link-separator"> </span>
-            <a href="${path + amendment.doi}" class="amendment-link">
+            <a href="${path + amendment.relatedArticle.doi}" class="amendment-link">
               View ${title?lower_case}
             </a>
           </@siteLink>

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -127,13 +127,13 @@
         <span><h5>
           <#nested/>
           <#if amendmentGroup.amendments?size == 1>
-            <a href="article?id=${amendmentGroup.amendments[0].doi}">
+            <a href="article?id=${amendmentGroup.amendments[0].relatedArticle.doi}">
               View ${amendmentType}
             </a>
           <#else>
             View
             <#list amendmentGroup.amendments as amendmentObject>
-              <a href="article?id=${amendmentObject.doi}">
+              <a href="article?id=${amendmentObject.relatedArticle.doi}">
               ${amendmentType} ${amendmentObject_index + 1}</a><#if amendmentObject_has_next>,</#if>
             </#list>
           </#if>

--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -157,9 +157,22 @@
         </@amendment>
       </#if>
       <#if amendmentGroup.type.name == 'update-forward'>
-        <@amendment amendmentGroup "update">
-          This article has been updated.
-        </@amendment>
+        <#if amendmentGroup.type.specificUse == 'registered-report-protocol'>
+          <@amendment amendmentGroup "research article">
+            This article has a related research article.
+          </@amendment>
+        <#else>  
+          <@amendment amendmentGroup "update">
+            This article has been updated.
+          </@amendment>
+        </#if>
+      </#if>
+      <#if amendmentGroup.type.name == 'updated-article'>
+        <#if amendmentGroup.type.specificUse == 'registered-report-protocol'>
+          <@amendment amendmentGroup "protocol">
+            This article has a registered report protocol.
+          </@amendment>
+        </#if>
       </#if>
     </#list>
 

--- a/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
@@ -221,6 +221,24 @@ public class ArticleMetadataTest extends AbstractJUnit4SpringContextTests {
   public void testFetchRelatedArticles() throws Exception {
     String doi = "10.9999/journal.xxxx.0";
     List<RelatedArticle> map = new Gson().fromJson(read("articleMeta/ppat.1005446.related.json"),
+        ArticleMetadata.Factory.RELATED_ARTICLE_GSON_TYPE);
+
+    ApiAddress address =
+        ApiAddress.builder("articles").embedDoi(doi).addToken("relationships").build();
+
+    when(articleApi.requestObject(address, ArticleMetadata.Factory.RELATED_ARTICLE_GSON_TYPE))
+        .thenReturn(map);
+    List<RelatedArticle> raList = articleMetadataFactory.fetchRelatedArticles(doi);
+    assertEquals(1, raList.size());
+    RelatedArticle ra = raList.get(0);
+    assertEquals("10.1371/journal.ppat.1006021", ra.getDoi());
+    assertEquals(null, ra.getSpecificUse());
+  }
+
+  @Test
+  public void testFetchRelatedArticlesWithSpecificUse() throws Exception {
+    String doi = "10.9999/journal.xxxx.0";
+    List<RelatedArticle> map = new Gson().fromJson(read("articleMeta/ppat.1005446.related2.json"),
                                                    ArticleMetadata.Factory.RELATED_ARTICLE_GSON_TYPE);
 
     ApiAddress address = ApiAddress.builder("articles").embedDoi(doi).addToken("relationships").build();
@@ -229,6 +247,6 @@ public class ArticleMetadataTest extends AbstractJUnit4SpringContextTests {
     List<RelatedArticle> raList = articleMetadataFactory.fetchRelatedArticles(doi);
     assertEquals(1, raList.size());
     RelatedArticle ra = raList.get(0);
-    assertEquals("10.1371/journal.ppat.1006021", ra.getDoi());
+    assertEquals("foo", ra.getSpecificUse());
   }
 }

--- a/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
+++ b/src/test/java/org/ambraproject/wombat/controller/ArticleMetadataTest.java
@@ -232,7 +232,7 @@ public class ArticleMetadataTest extends AbstractJUnit4SpringContextTests {
     assertEquals(1, raList.size());
     RelatedArticle ra = raList.get(0);
     assertEquals("10.1371/journal.ppat.1006021", ra.getDoi());
-    assertEquals(null, ra.getSpecificUse());
+    assertEquals(null, ra.getType().getSpecificUse());
   }
 
   @Test
@@ -247,6 +247,6 @@ public class ArticleMetadataTest extends AbstractJUnit4SpringContextTests {
     List<RelatedArticle> raList = articleMetadataFactory.fetchRelatedArticles(doi);
     assertEquals(1, raList.size());
     RelatedArticle ra = raList.get(0);
-    assertEquals("foo", ra.getSpecificUse());
+    assertEquals("foo", ra.getType().getSpecificUse());
   }
 }

--- a/src/test/java/org/ambraproject/wombat/model/RelatedArticleTypeTest.java
+++ b/src/test/java/org/ambraproject/wombat/model/RelatedArticleTypeTest.java
@@ -14,6 +14,15 @@ public class RelatedArticleTypeTest {
         RelatedArticleType.get("correction-forward"));
     assertEquals(RelatedArticleType.get("corrected-article"),
         RelatedArticleType.get("corrected-article"));
+    assertEquals("Correction",
+                 RelatedArticleType.get("corrected-article").getDisplayName());
+  }
+
+  @Test
+  public void testGetSpecificUse() {
+    RelatedArticleType type = RelatedArticleType.get("updated-article", "registered-report-protocol");
+    assertNotEquals(RelatedArticleType.get("updated-article"), type);
+    assertEquals("registered-report-protocol", type.getSpecificUse());
   }
 
   @Test

--- a/src/test/resources/articleMeta/ppat.1005446.related2.json
+++ b/src/test/resources/articleMeta/ppat.1005446.related2.json
@@ -1,0 +1,16 @@
+[
+    {
+        "type": "correction-forward",
+        "specificUse": "foo",
+        "doi": "10.1371/journal.ppat.1006021",
+        "revisionNumber": 1,
+        "title": "<article-title xmlns:mml=\"http://www.w3.org/1998/Math/MathML\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">Correction: Influenza Virus Targets Class I MHC-Educated NK Cells for Immunoevasion</article-title>",
+        "publicationDate": "2016-11-04",
+        "journal": {
+            "journalKey": "PLoSPathogens",
+            "title": "PLOS Pathogens",
+            "eIssn": "1553-7374"
+        }
+    }
+]
+


### PR DESCRIPTION
Testing:

1. Build this using `mvn install` so that it installs the package into `/var/tmp/apt`
1. Build https://github.com/PLOS/rhino/pull/508 using `mvn install`
1. Build https://github.com/PLOS/plos-themes/pull/1020 using `mvn install`
(whew)
1. ssh to `aa-stage.plos.org` and run:
  ```sh
  $ ploscli repackage dev http://journals-stage1-qc1.soma.plos.org:8006/v2   10.1371/journal.pone.0217207 --revision_number=1 --output=pone.0217207.zip
  $ ploscli repackage dev http://journals-stage1-qc1.soma.plos.org:8006/v2 10.1371/journal.pone.0213096 --revision_number=1 --output=pone.0213096.zip
  ```
5. rsync or scp these zip files to your desktop.
1. `cd pogos2/vagrant/apps/journals`
1. Run `vagrant up`
1. Run `mysql -u ambra -h journals.vagrant.test -pambra201 ambra < seed.sql`
1. Run `curl -X POST http://journals.vagrant.test:8002/v1/buckets -d name=corpus`
1. Run `./ingest path/to/pone.0213096.zip`
1. Run `./ingest path/to/pone.0217207.zip`
1. Visit http://journals.vagrant.test/plosone/article?id=10.1371/journal.pone.0213096
1. Visit http://journals.vagrant.test/plosone/article?id=10.1371/journal.pone.0217207

![image](https://user-images.githubusercontent.com/22718/72112252-e80e9b80-32f1-11ea-8a42-c721880be284.png)
![image](https://user-images.githubusercontent.com/22718/72112267-efce4000-32f1-11ea-8cad-e68d329e80c1.png)

## Note
The decrease in test coverage seems to be some strange artifact of using google auto-value or something? I have excluded auto-generated code from the test coverage and now the test coverage percentage has gone down. Please use your own judgment as to whether or not this code is sufficiently tested.