### PR TITLE
AMBR-1074 Fix call to specificUse

### DIFF
--- a/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
+++ b/src/main/webapp/WEB-INF/themes/mobile/ftl/article/articlePrefix.ftl
@@ -157,7 +157,7 @@
         </@amendment>
       </#if>
       <#if amendmentGroup.type.name == 'update-forward'>
-        <#if amendmentGroup.type.specificUse == 'registered-report-protocol'>
+        <#if amendmentGroup.type.specificUse?? && amendmentGroup.type.specificUse == 'registered-report-protocol'>
           <@amendment amendmentGroup "research article">
             This article has a related research article.
           </@amendment>
@@ -168,7 +168,7 @@
         </#if>
       </#if>
       <#if amendmentGroup.type.name == 'updated-article'>
-        <#if amendmentGroup.type.specificUse == 'registered-report-protocol'>
+        <#if amendmentGroup.type.specificUse?? && amendmentGroup.type.specificUse == 'registered-report-protocol'>
           <@amendment amendmentGroup "protocol">
             This article has a registered report protocol.
           </@amendment>


### PR DESCRIPTION
In freemarker, apparently one cannot access a null value at all.