### PR TITLE
AMBR-1103 stop calling nonexistent redirect logging service

### DIFF
--- a/src/main/webapp/WEB-INF/themes/root/ftl/redirect.ftl
+++ b/src/main/webapp/WEB-INF/themes/root/ftl/redirect.ftl
@@ -44,15 +44,6 @@ This page has moved. Please click <a href="<@siteLink path='${defaultTarget}'/>"
     }
   }
 
-  // Ajax URL should be set as a redirect in Apache. The redirect destination is arbitrary and
-  // response is ignored. This request will allow logging of Javascript-based redirects as if
-  // they were standard Apache redirects.
-  var xmlhttp = new XMLHttpRequest();
-  var url = "<@siteLink path=''/>" + 'logRedirect/' + encodeURIComponent(source)
-      + '/' + encodeURIComponent(current_anchor.replace('#', ''));
-  xmlhttp.open('POST', url, false /*async*/);
-  xmlhttp.send();
-
   window.location.replace("<@siteLink path='" + target + "'/>");
 
 </script>


### PR DESCRIPTION

http://journals.vagrant.test/plosone/redirect/guidelines#fungal
![Screenshot from 2020-01-22 15-37-03](https://user-images.githubusercontent.com/1165691/72944192-15653b80-3d2d-11ea-8af4-08be72a0c767.png)
You should no longer see a 403 error in the Network tab of your browser tools when you invoke a client-side redirect. You will, however, get a 404 because there is no static page service configured in vagrant


compare to:
https://journals-dev.plos.org/plosone/redirect/guidelines#fungal
![Screenshot from 2020-01-22 15-29-18](https://user-images.githubusercontent.com/1165691/72943900-22355f80-3d2c-11ea-8af8-62002a0d6317.png)
