### PR TITLE
AMBR-1108 new journal logos

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/common/header/headerContent.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/common/header/headerContent.ftl
@@ -47,7 +47,12 @@
       </li>
 
       </ul>     <#--opened in siteMenu.ftl -->
+
       </section>  <#--opened in siteMenu.ftl -->
+
+      <h1 class="logo">
+        <a href="<@siteLink path="." />">${siteTitle}</a>
+      </h1>
     </nav>
   </div><#-- pagehdr-->
 

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/common/siteMenu/siteMenu.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/common/siteMenu/siteMenu.ftl
@@ -126,10 +126,6 @@
 <#--Markup starts here
 MARKUP: using Foundation Top Bar for navigation -->
 
-<h1 class="logo">
-  <a href="<@siteLink path="." />">${siteTitle}</a>
-</h1>
-
 <section class="top-bar-section"> <#--closed in headerContainer.ftl-->
 
 <ul class="nav-elements">

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
@@ -1122,7 +1122,13 @@ body.article .ui-widget-overlay {
     margin-top: $pad-xsmall;
 
     &:before {
-      content: image-url('logo.png') !important;
+      height: 50px;
+      width: 550px;
+      display: inline-block;
+      background-image: image-url('logo.svg');
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: 0 center;
     }
 
     h1 {

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
@@ -94,30 +94,33 @@ $width-nav: $block-grid-elements - $width-logo;
     }
   }
   
+header .top-bar-section {
+  float: right;
+}
+
+header .nav-main .logo {
+  height: 50px;
+  width: 565px;
+  margin-top: -24px;
+}
+
+.plosntds header .nav-main .logo {
+  height: 22px;
+}
 
 .logo {
   @include plos-grid-column($columns: $width-logo);
   @extend .title-area; // foundation
   @include icon-offscreen;
-  height: rem-calc(41);
   //brand-specific logo in plos-themes/code/desktop/[BRAND]/resource/img :
-  background: image-url('logo.png') no-repeat 0 0;
+  background: image-url('logo.svg') no-repeat 0 0;
+  background-size: contain;
 
   a{
     display:block;
     height: 100%;
     }
   }
-
-// Anniversary logo height and position override
-.plosone, .plosntd, .plosbiology {
-  header {
-    .logo {
-      margin-top: rem-calc(-9);
-      height: rem-calc(58);
-    }
-  }
-}
 
 /* using Foundation Top Bar
  all @extend .class are Foundation
@@ -126,7 +129,7 @@ $width-nav: $block-grid-elements - $width-logo;
 .nav-main {
   @extend .plos-row;
   @extend .top-bar; // foundation
-  margin-bottom: $pad-default;
+  margin-bottom: 50px;
   font-family: $font-face-navigation;
   > .dropdown {
     visibility: hidden;


### PR DESCRIPTION
https://jira.plos.org/jira/browse/AMBR-1108

companion PR in plos-themes: https://github.com/PLOS/plos-themes/pull/1027

This addresses the logos on desktop, mobile and in print.  It does not address one odd usage of the logo for Powerpoint slides which has been spun off to https://jira.plos.org/jira/browse/AMBR-1117.

To package wombat and deploy to vagrant
```
cd ../plos-themes && git checkout AMBR-1108
cd ../wombat && git checkout AMBR-1108
mvn clean install
cd ../pogos2/vagrant/apps/journals
vagrant destroy -f && vagrant up
./seed
```

Copy changes from plos-themes to vagrant
```
cd plos-themes/..  # the next line must be run from the parent dir of the plos-themes repo
# copy the tree of relevant files to the vagrant app
find plos-themes \( -name '*.css' -or -name '*.svg' \) -exec cp --parents \{\} ~/pogos2/vagrant/apps/journals/ \;
cd ~/pogos2/vagrant/apps/journals
vagrant ssh
cp -r /vagrant/apps/journals/plos-themes/* /opt/plos/wombat/var/themes/
```

Seed data for vagrant is missing data for journal front pages. One solution would be to add to the seed data but I didn't get to that. Another is to point to the journals dev backend:
```
vagrant ssh
sudo su
sed -i -e 's|http://main\.journals-backend\.service\.vagrant:8006/v2/|https://journals-dev1-backend1\.soma\.plos\.org:8006/v2/|' /opt/plos/wombat/conf/wombat.yaml
service wombat restart
```

To verify, browse http://journals.vagrant.test/plosbiology.
See new logo at the top. Logos should match the screenshots attached to the jira ticket.
To test mobile and print, Firefox dev tools includes a mobile emulator and a print media simulator.