### PR TITLE
AMBR-1108 logo is below the top nav

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/pages/_article.scss
@@ -1122,7 +1122,12 @@ body.article .ui-widget-overlay {
     margin-top: $pad-xsmall;
 
     &:before {
-      content: image-url('logo.png') !important;
+      height: 50px;
+      width: 100%;
+      background-image: image-url('logo.png');
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: left bottom;
     }
 
     h1 {

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
@@ -111,9 +111,11 @@ $width-nav: $block-grid-elements - $width-logo;
   }
 }
 
+// adding specificity to override included styles
 #pagehdr .nav-main .logo {
   position: absolute;
   float: none;
+  margin-left: .625rem;
 }
 
 .ploscompbiol .logo {

--- a/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
+++ b/src/main/webapp/WEB-INF/themes/desktop/sass/sections/_header.scss
@@ -93,31 +93,41 @@ $width-nav: $block-grid-elements - $width-logo;
       }
     }
   }
-  
 
 .logo {
   @include plos-grid-column($columns: $width-logo);
   @extend .title-area; // foundation
   @include icon-offscreen;
-  height: rem-calc(41);
+  height: 40px;
+  width: 100%;
+  bottom: 0;
   //brand-specific logo in plos-themes/code/desktop/[BRAND]/resource/img :
   background: image-url('logo.png') no-repeat 0 0;
+  background-size: contain;
 
-  a{
+  a {
     display:block;
     height: 100%;
-    }
-  }
-
-// Anniversary logo height and position override
-.plosone, .plosntd, .plosbiology {
-  header {
-    .logo {
-      margin-top: rem-calc(-9);
-      height: rem-calc(58);
-    }
   }
 }
+
+#pagehdr .nav-main .logo {
+  position: absolute;
+  float: none;
+}
+
+.ploscompbiol .logo {
+  height: 27px;
+}
+
+.plosntd .logo {
+  height: 24px;
+}
+
+.plosone .logo {
+  height: 58px;
+}
+
 
 /* using Foundation Top Bar
  all @extend .class are Foundation
@@ -132,6 +142,10 @@ $width-nav: $block-grid-elements - $width-logo;
     visibility: hidden;
     }
   }
+
+.nav-main .top-bar-section {
+  float: right;
+}
 
 .top-bar-section {
   @extend .hide-for-print;
@@ -156,6 +170,7 @@ $width-nav: $block-grid-elements - $width-logo;
   // foundation
   @include plos-grid-column-nomargin($pixelwidth: columns, $columns: $width-nav, $float: right);
   width: 40.83333rem;
+
   h2, h3 {
     font-family: $font-face-navigation;
     font-size: $txt-size-xlarge;


### PR DESCRIPTION
https://jira.plos.org/jira/browse/AMBR-1108

companion PR in plos-themes: https://github.com/PLOS/plos-themes/pull/1028

This replaces the journal logos on desktop, mobile and in print.  

To package wombat and deploy to vagrant
```
cd ../plos-themes && git checkout AMBR-1108
cd ../wombat && git checkout AMBR-1108
mvn clean install
cd ~/pogos2/vagrant/apps/journals
vagrant destroy -f && vagrant up
./seed
```

Copy changes from plos-themes to vagrant
```
cd plos-themes/..  # the next line must be run from the parent dir of the plos-themes repo
# copy the tree of this PR's relevant files to the vagrant app
find plos-themes \( -name 'plos-interface.css' -or -name 'logo.png' \) -exec cp --parents \{\} ~/pogos2/vagrant/apps/journals/ \;
cd ~/pogos2/vagrant/apps/journals
vagrant ssh
cp -r /vagrant/apps/journals/plos-themes/* /opt/plos/wombat/var/themes/
rm /opt/plos/wombat/var/themes/code/desktop/journals/*/resource/img/logo.png
```

Vagrant data is missing for journal front pages. One solution would be to add to the seed data but I didn't get to that. Another is to point to the journals dev backend:
```
vagrant ssh
sudo su
sed -i -e 's|http://main\.journals-backend\.service\.vagrant:8006/v2/|http://journals-dev1-backend1\.soma\.plos\.org:8006/v2/|' /opt/plos/wombat/conf/wombat.yaml
service wombat restart
```

To verify, browse http://journals.vagrant.test/plosbiology.
See new logo at the top. Logos should match the screenshots attached to the jira ticket.
To test mobile use a mobile emulator like Firefox dev tools
The logo also appears in print, but only when printing an article e.g. http://journals.vagrant.test/plosone/article?id=10.1371/journal.pone.0174958, not a journal homepage. Firefox dev tools a print media simulator.
