### PR TITLE
AMBR-1144 Rename generic_blogfeed to logo-plos-imageonly

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/blogfeed.js
+++ b/src/main/webapp/WEB-INF/themes/desktop/resource/js/components/blogfeed.js
@@ -46,7 +46,7 @@ function feedLoaded(blog_feed, blogPostCount, blogContainer) {
 
           blogImg = entry.thumbnail;
           if (blogImg == null) {
-            blogImg = "resource/img/generic_blogfeed.png";
+            blogImg = "resource/img/logo-plos-imageonly.png";
           }
 
           // TODO - need to move the link to the default image out of the JS.


### PR DESCRIPTION
https://jira.plos.org/jira/browse/AMBR-1144

Unfortunately, because of CORS I couldn't test this, I just get an error. :crossed_fingers: it works.

![image](https://user-images.githubusercontent.com/22718/77782683-e3b26e80-7014-11ea-9a97-d0543a9ba2ee.png)


See also https://github.com/PLOS/plos-themes/pull/1051