### PR TITLE
ENG-67 Redirect to URL on startup (do not display root page)

### DIFF
--- a/src/main/java/org/ambraproject/wombat/config/RuntimeConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/RuntimeConfiguration.java
@@ -86,7 +86,7 @@ public interface RuntimeConfiguration {
   /**
    * Get the path of an HTML document to display on the root page
    */
-  String getRootPagePath();
+  String getRootRedirect();
 
   /**
    * Get the name of the runtime environment ("prod", "dev", etc.)

--- a/src/main/java/org/ambraproject/wombat/config/YamlConfiguration.java
+++ b/src/main/java/org/ambraproject/wombat/config/YamlConfiguration.java
@@ -89,8 +89,8 @@ public class YamlConfiguration implements RuntimeConfiguration {
   }
 
   @Override
-  public String getRootPagePath() {
-    return input.rootPagePath;
+  public String getRootRedirect() {
+    return input.rootRedirect;
   }
 
   @Override
@@ -332,7 +332,7 @@ public class YamlConfiguration implements RuntimeConfiguration {
 
     private String server;
     private String compiledAssetDir;
-    private String rootPagePath;
+    private String rootRedirect;
     private String environment;
     private List<String> enableDevFeatures;
     private List<Map<String, ?>> themeSources;
@@ -365,8 +365,8 @@ public class YamlConfiguration implements RuntimeConfiguration {
      * @deprecated For access by reflective deserializer only
      */
     @Deprecated
-    public void setRootPagePath(String rootPagePath) {
-      this.rootPagePath = rootPagePath;
+    public void setRootRedirect(String rootRedirect) {
+      this.rootRedirect = rootRedirect;
     }
 
     /**

--- a/src/main/java/org/ambraproject/wombat/controller/AppRootPage.java
+++ b/src/main/java/org/ambraproject/wombat/controller/AppRootPage.java
@@ -39,11 +39,11 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.ui.ExtendedModelMap;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
-
+import org.springframework.web.servlet.view.RedirectView;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -103,11 +103,13 @@ public class AppRootPage {
    * Show a page in response to the application root.
    */
   ModelAndView serveAppRoot() {
-    String rootPagePath = runtimeConfiguration.getRootPagePath();
-    if (Strings.isNullOrEmpty(rootPagePath)) {
+    if (!runtimeConfiguration.getEnvironment().equals("prod")) {
       return serveDebugPage();
     } else {
-      return serveCustomRootPage(rootPagePath);
+      RedirectView rv = new RedirectView();
+      rv.setStatusCode(HttpStatus.MOVED_PERMANENTLY);
+      rv.setUrl(runtimeConfiguration.getRootRedirect());
+      return new ModelAndView(rv);
     }
   }
 
@@ -122,12 +124,6 @@ public class AppRootPage {
       log.error("Error displaying root page image", e);
     }
     return mav;
-  }
-
-  private ModelAndView serveCustomRootPage(String rootPagePath) {
-    ExtendedModelMap model = new ExtendedModelMap();
-    model.addAttribute("rootPage", new File(rootPagePath));
-    return new ModelAndView(HtmlFileView.INSTANCE, model);
   }
 
   private String getResourceAsBase64(String path) throws IOException {

--- a/src/main/java/org/ambraproject/wombat/controller/ExceptionHandlerAdvisor.java
+++ b/src/main/java/org/ambraproject/wombat/controller/ExceptionHandlerAdvisor.java
@@ -83,7 +83,7 @@ class ExceptionHandlerAdvisor {
     exception.printStackTrace(new PrintWriter(stackTrace));
     mav.addObject("stackTrace", stackTrace.toString());
 
-    mav.addObject("environment", runtimeConfiguration.getEnvironment().toString());
+    mav.addObject("environment", runtimeConfiguration.getEnvironment());
 
     return mav;
   }

--- a/src/test/java/org/ambraproject/wombat/config/TestRuntimeConfiguration.java
+++ b/src/test/java/org/ambraproject/wombat/config/TestRuntimeConfiguration.java
@@ -62,7 +62,7 @@ public class TestRuntimeConfiguration implements RuntimeConfiguration {
   }
 
   @Override
-  public String getRootPagePath() {
+  public String getRootRedirect() {
     return null;
   }
 


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ENG-67

I refactored the way the "debug" page is displayed so that it is never displayed if the `env` setting is set to `prod` (the default).
