### PR TITLE
ENG-80 Fix spacing on print link

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/print.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/print.ftl
@@ -24,10 +24,7 @@
 
   Print
   <ul class="print-options" data-js-tooltip-hover="target">
-    <li>
-        <a href="#" onclick="window.print(); return false;" class="preventDefault" id="printBrowser" title="Print
-        Article">Print article</a>
-    </li>
-  <#include "printService.ftl" />
+    <li><a href="#" onclick="window.print(); return false;" class="preventDefault" id="printBrowser">Print article</a></li>
+    <#include "printService.ftl" />
   </ul>
 </div>


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ENG-80

Fix spacing on print link

After this fix: 
![image](https://user-images.githubusercontent.com/22718/79157669-dd98ed80-7d89-11ea-8215-74f86baadbd9.png)

See JIRA ticket for problem.
