### PR TITLE
Eng 55

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3'
 
-# NOTE: You must set WOMBAT_TAG, RHINO_TAG and PLOS_THEMES_REPO environment variables
+# NOTE: You must set PLOS_THEMES_REPO environment variables
 #       as well as all environment variables not explicitly defined below (e.g. CAS_URL)
 
 services:
 
   wombat:
-    image: plos/wombat:${WOMBAT_TAG}
+    image: plos/wombat:latest
     depends_on:
       - db
       - rhino
@@ -27,7 +27,7 @@ services:
       - ${PLOS_THEMES_REPO}:/opt/plos/themes:ro
 
   rhino:
-    image: plos/rhino:${RHINO_TAG}
+    image: plos/rhino:latest
     depends_on:
       - db
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+# NOTE: You must set WOMBAT_TAG, RHINO_TAG and PLOS_THEMES_REPO environment variables
+#       as well as all environment variables not explicitly defined below (e.g. CAS_URL)
+
+services:
+
+  wombat:
+    image: plos/wombat:${WOMBAT_TAG}
+    depends_on:
+      - db
+      - rhino
+    environment:
+      - CAS_URL
+      - NED_URL
+      - SOLR_URL
+      - ENVIRONMENT=dev
+      - LOG_LEVEL=debug
+      - RHINO_URL=http://rhino:8080/rhino/
+      - THEME_PATH=/opt/plos/themes
+    links:
+      - db
+      - rhino
+    ports:
+      - 8015:8080
+    volumes:
+      - ${PLOS_THEMES_REPO}:/opt/plos/themes:ro
+
+  rhino:
+    image: plos/rhino:${RHINO_TAG}
+    depends_on:
+      - db
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_ROLE_ARN
+      - AWS_SECRET_ACCESS_KEY
+      - CONTENT_REPO_URL
+      - CORPUS_BUCKET
+      - TAXONOMY_URL
+      - THESAURUS
+      - DATABASE_URL='jdbc:mysql://db:3306/ambra?user=root&password=password'
+      - JAVA_OPTS=-DDATABASE_URL='jdbc:mysql://db:3306/ambra?user=root&password=password'
+    links:
+      - db
+    ports:
+      - 8006:8080
+
+  db:
+    image: mysql:5.7.29
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: ambra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       - TAXONOMY_URL
       - THESAURUS
       - DATABASE_URL='jdbc:mysql://db:3306/ambra?user=root&password=password'
-      - JAVA_OPTS=-DDATABASE_URL='jdbc:mysql://db:3306/ambra?user=root&password=password'
     links:
       - db
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
-# NOTE: You must set PLOS_THEMES_REPO environment variables
-#       as well as all environment variables not explicitly defined below (e.g. CAS_URL)
+# NOTE: You must set the PLOS_THEMES_REPO environment variables as well as all
+#       environment variables not explicitly defined below (e.g. CAS_URL)
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,11 @@ services:
     depends_on:
       - db
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_ROLE_ARN
-      - AWS_SECRET_ACCESS_KEY
       - CONTENT_REPO_URL
       - CORPUS_BUCKET
       - TAXONOMY_URL
       - THESAURUS
-      - DATABASE_URL='jdbc:mysql://db:3306/ambra?user=root&password=password'
+      - DATABASE_URL=jdbc:mysql://db:3306/ambra?user=root&password=password
     links:
       - db
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -564,6 +564,9 @@
         <configuration>
           <to>
             <image>docker.io/plos/wombat:${project.version}</image>
+            <tags>
+              <tag>latest</tag>
+            </tags>
           </to>
           <from>
             <image>docker.io/plos/tomcat:latest</image>

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,25 @@
           <workingDirectory>src/main/webapp/WEB-INF/themes/desktop</workingDirectory>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>2.1.0</version>
+        <configuration>
+          <to>
+            <image>docker.io/plos/wombat:${project.version}</image>
+          </to>
+          <from>
+            <image>docker.io/plos/tomcat:latest</image>
+          </from>
+          <container>
+            <appRoot>/usr/local/tomcat/webapps/wombat</appRoot>
+          </container>
+        </configuration>
+      </plugin>
     </plugins>
+
     <pluginManagement>
       <plugins>
         <!-- Configure eclipse to skip building assets with gulp/npm.


### PR DESCRIPTION
This PR adds a jib configuration for creating a docker image for wombat. I've also added a docker-compose.yml for testing.

I considered a few ways to implement themes. For now I've chosen to just mount these as a volume. The reason being it's ultimately the most flexible way to include data, including in a k8s deployment, where the data could be attached as a persistent volume claim that abstracts the actual data source type (e.g. could be GCS).

To build the docker image, run `mvn clean package jib:dockerBuild` or you can pull these:
- plos/rhino:2.5.9-SNAPSHOT
- plos/wombat:3.7.17-SNAPSHOT

First set the necessary environment variables (explained in docker-compose.yml). Then docker-compose up, wait a minute and open (http://localhost:8015/wombat/DesktopGeneric). You should see "You have setup Wombat correctly!"

docker-compose will start a mysql instance on port 3306 so stop anything listening on that port. This port can(should?) be changed to something else for local development but I'm not sure if we have a standard for that yet.

 