### PR TITLE
Empowerment: load resources more efficiently

### DIFF
--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/crossmark.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/aside/crossmark.ftl
@@ -23,7 +23,7 @@
  <@themeConfig map="article" value="showCrossMarkWidget" ; showCrossMarkWidget>
     <#if showCrossMarkWidget>
 <!-- Crossmark 2.0 widget -->
-<script src="https://crossmark-cdn.crossref.org/widget/v2.0/widget.js"></script>
+<script defer src="https://crossmark-cdn.crossref.org/widget/v2.0/widget.js"></script>
 <a data-target="crossmark"><img width="150" src="https://crossmark-cdn.crossref.org/widget/v2.0/logos/CROSSMARK_BW_horizontal.svg"></a>
 <!-- End Crossmark 2.0 widget -->
     </#if>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/figure_carousel.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/figure_carousel.ftl
@@ -34,6 +34,7 @@
 
               <@siteLink handlerName="figureImage" queryParameters=(versionPtr + {"size": "inline", "id": figure.doi}) ; src>
                 <img src="${src?html}"
+                     loading="lazy"
                      <#if figure.title?has_content >
                      alt="${figure.title?html}"
                      </#if>

--- a/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
+++ b/src/main/webapp/WEB-INF/themes/desktop/ftl/article/mathjax.ftl
@@ -37,4 +37,4 @@ MathJax.Hub.Config({
 });
 </script>
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=MML_HTMLorMML"></script>
+<script defer type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=MML_HTMLorMML"></script>

--- a/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
+++ b/src/main/webapp/WEB-INF/themes/desktop/xform/article-transform.xsl
@@ -1413,6 +1413,7 @@
               </xsl:attribute>
               <xsl:attribute name="alt">thumbnail</xsl:attribute>
               <xsl:attribute name="class">thumbnail</xsl:attribute>
+              <xsl:attribute name="loading">lazy</xsl:attribute>
             </xsl:element>
           </xsl:element>
           <div class="expand"/>


### PR DESCRIPTION
Just something thats been bugging me regarding website performance

Regarding image tags: modern browsers will only load these once they are nearing the viewport. When a user lands on a desktop article page nearly all images are loaded offscreen anyways. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes

Regarding script tags: I only added defer to third party standalone stuff, so it shouldn't affect much. (crossref is just a button at the top, ~~figshare is a widget at the bottom~~ and mathjax mucks around with formula formats) See https://alligator.io/html/defer-async/
EDIT: undid the figshare defer, there is some synchronous code that depends on it. Thinking of a better solution.

Thoughts?
Our most viewed articles of the year have abysmal load times:
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/5441006/81240547-85d25880-8fbc-11ea-9f6b-7f8e97e21261.png">


For DOI 10.1371/journal.pone.0083152 with warm cache it looks like this:

OLD
![image](https://user-images.githubusercontent.com/5441006/81238171-35f09300-8fb6-11ea-9a05-fe506f79e9a7.png)
NEW
![image](https://user-images.githubusercontent.com/5441006/81238183-3db03780-8fb6-11ea-9b31-b0392add7317.png)

Slimmer pages!