### PR TITLE
ENG-119 Use *:* as solr query when the query is the empty string

### DIFF
--- a/src/main/java/org/ambraproject/wombat/service/remote/ArticleSearchQuery.java
+++ b/src/main/java/org/ambraproject/wombat/service/remote/ArticleSearchQuery.java
@@ -262,7 +262,18 @@ public abstract class ArticleSearchQuery {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract ArticleSearchQuery build();
+    abstract String getQuery();
+
+    abstract ArticleSearchQuery autoBuild();
+
+    public ArticleSearchQuery build() {
+      /* An empty query is meaningless and means find all.*/
+      if (this.getQuery().equals("")) {
+        this.setQuery("*:*");
+        this.setSimple(false);
+      }
+      return autoBuild();
+    }
 
     /**
      * Set the raw search query

--- a/src/test/java/org/ambraproject/wombat/service/remote/SolrSearchApiTest.java
+++ b/src/test/java/org/ambraproject/wombat/service/remote/SolrSearchApiTest.java
@@ -24,6 +24,7 @@ package org.ambraproject.wombat.service.remote;
 
 import static org.ambraproject.wombat.util.FileUtils.read;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -282,6 +283,15 @@ public class SolrSearchApiTest extends AbstractJUnit4SpringContextTests {
     assert(facets.keySet().contains("subject_facet"));
     Map<String, Integer> subjectFacet = facets.get("subject_facet");
     assertEquals(Integer.valueOf(2), subjectFacet.get("Gene mapping"));
+  }
+
+  @Test
+  public void testEmptyQuery() throws IOException {
+    ArticleSearchQuery asq = ArticleSearchQuery.builder()
+      .setQuery("")
+      .build();
+    assertFalse(asq.isSimple());
+    assertEquals("*:*", asq.getQuery());
   }
 
   @Test


### PR DESCRIPTION
in ENG-119, I rewrote a lot of the query generation code, but I broke existing logic which did a wildcard query when the search was empty. This broke the search that you get when you click on a subject.

Compare (broken): https://journals-dev.plos.org/plosone/search?filterSubjects=Beetles&filterJournals=PLoSONE&q= with (working) https://journals.plos.org/plosone/search?filterSubjects=Beetles&filterJournals=PLoSONE&q=

Screenshot of this working locally after this change:
![image](https://user-images.githubusercontent.com/22718/82078219-9f972e00-9695-11ea-8fba-c93ae4447a86.png)

