### PR TITLE
ENG-211

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ files, as well as containing several configuration options.
 Runtime configuration happens via environment variables:
 
 - `CAS_URL`: base url for CAS server
-- `LOG_LEVEL`: (optional) level of logging, defaults to `warn`
+- `COLLECTIONS_URL`: URL for the collections server, used for links
 - `DEBUG`: (optional) set to true to show debug info if a page errors
+- `LOG_LEVEL`: (optional) level of logging, defaults to `warn`
 - `MECACHED_SERVER`: (optional) `hostname:port` for memcached server to use
 - `NED_URL`: the URL for the ned server, including username and password
 - `RHINO_URL`: complete url to rhino server
@@ -27,6 +28,40 @@ See the [Ambra Project documentation](https://plos.github.io/ambraproject/) for
 an overview of the stack and user instructions. If you have any questions or
 comments, please email dev@ambraproject.org, open a [GitHub
 issue](https://github.com/PLOS/wombat/issues), or submit a pull request.
+
+## Docker
+
+Wombat is intended to be run in docker.
+
+To build the docker image, run:
+
+```
+mvn package jib:dockerBuild
+```
+
+To set up the configuration for docker-compose, run:
+
+```
+cat > .env <<EOS
+CAS_URL=https://nedcas-integration.plos.org/cas/
+COLLECTIONS_URL=http://collections-dev.plos.org/
+CONTENT_REPO_URL=http://dev-main.journals-contentrepo.service.consul:8002/v1/ # for rhino
+CORPUS_BUCKET=mogilefs-prod-repo # for rhino
+NED_URL=http://dipro:XXX@nac-390.soma.plos.org:8888/v1/
+PLOS_THEMES_REPO=/path/to/plos-themes/
+SOLR_URL=http://solr-mega-dev.soma.plos.org/solr/journals_dev/
+TAXONOMY_URL=https://plos.accessinn.com:9138/servlet/dh # for rhino
+THESAURUS=plosthes.2020-1 # for rhino
+EOS
+```
+
+You will need to edit this `.env` file to point to your `plos-themes` checkout and set your password for NED (currently `XXX` above).
+
+You can then run:
+
+```
+docker-compose up
+```
 
 [Build Status]: https://teamcity.plos.org/teamcity/viewType.html?buildTypeId=Wombat_Build
 [Build Status Badge]: https://teamcity.plos.org/teamcity/app/rest/builds/buildType:(id:Wombat_Build)/statusIcon.svg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - db
       - rhino
       - memcached
-    ports:
-      - 8015:8080
+    expose:
+      - 8080
     volumes:
       - ${PLOS_THEMES_REPO}:/opt/plos/themes:ro
 
@@ -52,3 +52,12 @@ services:
 
   memcached:
     image: memcached:latest
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - wombat
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - SOLR_URL
       - DEBUG
       - LOG_LEVEL
-      - RHINO_URL=http://rhino:8080/rhino/
+      - RHINO_URL=${RHINO_URL:-http://rhino:8080/rhino/}
       - THEME_PATH=/opt/plos/themes
       - COLLECTIONS_URL
       - MEMCACHED_SERVER=memcached:11211

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,11 @@ services:
       - RHINO_URL=http://rhino:8080/rhino/
       - THEME_PATH=/opt/plos/themes
       - COLLECTIONS_URL
+      - MEMCACHED_SERVER=memcached:11211
     links:
       - db
       - rhino
+      - memcached
     ports:
       - 8015:8080
     volumes:
@@ -47,3 +49,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: ambra
+
+  memcached:
+    image: memcached:latest

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+user  nginx;
+
+events {
+    worker_connections   1000;
+}
+
+http {
+    server {
+        listen 8080;
+        location / {
+            # Docker uses round robin DNS, so this will load balance
+            # between the wombat instances. Note that this will not
+            # work with sessions.
+            proxy_pass http://wombat:8080;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
             <image>docker.io/plos/tomcat:latest</image>
           </from>
           <container>
-            <appRoot>/usr/local/tomcat/webapps/wombat</appRoot>
+            <appRoot>/usr/local/tomcat/webapps/ROOT</appRoot>
           </container>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>2.1.0</version>
+        <version>2.3.0</version>
         <configuration>
           <to>
             <image>docker.io/plos/wombat:${project.version}</image>


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ENG-211

This was a journey. What I learned:

1. We do not use memcached for session storage, but instead use tomcat's built in mechanism.
2. Session storage for spring actually seems to happen in tomcat (the container). Our best bet for not using sticky sessions any more is probably tomcat’s “cluster” https://tomcat.apache.org/tomcat-8.5-doc/cluster-howto.html option.
3. A lot about docker and docker-compose

In the end, I found there seems to be no obvious problem with sharing memcached between tomcats.

I have made some changes to the docker build and `docker-compose.yml` to allow testing this.

1. Added memcached to the `docker-compose.yml`
2. Added a dead-simple load balancer to docker to allow us to scale wombat horizontally.
3. Updated the README to how to make docker-compose work.

To test:
1. Follow new README instructions (https://github.com/plos/wombat/blob/ENG-211/README.md#docker)
2. Add `RHINO_URL=http://journals-dev1-backend1.soma.plos.org:8006/v2/` to your `.env` to use existing rhino content.
3. Run `docker-compose up --scale wombat=3` to start with 3 wombats.
4. Visit http://localhost:8080/DesktopPlosOne/article/comments?id=10.1371/journal.pone.0205192 in multiple browser windows, or choose some other way of hammering on the server to try to find any issues.